### PR TITLE
feat: 즐겨찾기 탭 커스텀 버튼 구현 및 바텀시트 트리거 연결

### DIFF
--- a/front/src/api/favoriteApi.ts
+++ b/front/src/api/favoriteApi.ts
@@ -1,0 +1,16 @@
+import axiosInstance from './axiosInstance';
+
+const favoriteApi = {
+  // 즐겨찾기 목록 조회
+  getFavorites: () => axiosInstance.get('/favorites'),
+
+  // 즐겨찾기 추가
+  addFavorite: (buildingId: number) =>
+    axiosInstance.post(`/favorites/${buildingId}`),
+
+  // 즐겨찾기 삭제
+  removeFavorite: (buildingId: number) =>
+    axiosInstance.delete(`/favorites/${buildingId}`),
+};
+
+export default favoriteApi;

--- a/front/src/components/FavoriteBottomSheetContent.tsx
+++ b/front/src/components/FavoriteBottomSheetContent.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {View, Text, FlatList, TouchableOpacity, StyleSheet} from 'react-native';
+
+type FavoriteItem = {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+};
+
+interface Props {
+  favorites: FavoriteItem[];
+  onSelect: (item: FavoriteItem) => void;
+}
+
+export default function FavoriteBottomSheetContent({
+  favorites,
+  onSelect,
+}: Props) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>📌 내 즐겨찾기</Text>
+      {favorites.length === 0 ? (
+        <Text style={{marginTop: 10}}>등록된 즐겨찾기가 없어요.</Text>
+      ) : (
+        <FlatList
+          data={favorites}
+          keyExtractor={item => item.id.toString()}
+          renderItem={({item}) => (
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => onSelect(item)}>
+              <Text style={styles.itemText}>{item.name}</Text>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {padding: 20},
+  title: {fontSize: 20, fontWeight: 'bold', marginBottom: 10},
+  item: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  itemText: {fontSize: 16},
+});

--- a/front/src/contexts/FavoriteSheetContext.tsx
+++ b/front/src/contexts/FavoriteSheetContext.tsx
@@ -1,0 +1,67 @@
+import React, {createContext, useContext, useState, ReactNode} from 'react';
+import BottomSheet from '@gorhom/bottom-sheet';
+import FavoriteBottomSheetContent from '../components/FavoriteBottomSheetContent';
+import favoriteApi from '../api/favoriteApi';
+
+type FavoriteItem = {
+  id: number;
+  name: string;
+  latitude: number;
+  longitude: number;
+};
+
+type ContextValue = {
+  open: () => void;
+  close: () => void;
+};
+
+const FavoriteSheetContext = createContext<ContextValue | null>(null);
+
+export const FavoriteSheetProvider = ({children}: {children: ReactNode}) => {
+  const [visible, setVisible] = useState(false);
+  const [data, setData] = useState<FavoriteItem[]>([]);
+
+  const open = () => {
+    // API 로딩
+    favoriteApi.getFavorites().then(res => {
+      setData(
+        res.data.buildings.map((b: any) => ({
+          id: b.buildingId,
+          name: b.buildingName,
+          latitude: 0,
+          longitude: 0,
+        })),
+      );
+      setVisible(true);
+    });
+  };
+  const close = () => setVisible(false);
+
+  return (
+    <FavoriteSheetContext.Provider value={{open, close}}>
+      {children}
+      <BottomSheet
+        index={visible ? 0 : -1}
+        snapPoints={['40%', '90%']}
+        enablePanDownToClose
+        onClose={close}>
+        <FavoriteBottomSheetContent
+          favorites={data}
+          onSelect={item => {
+            /* 선택 처리 */
+            close();
+          }}
+        />
+      </BottomSheet>
+    </FavoriteSheetContext.Provider>
+  );
+};
+
+export const useFavoriteSheet = () => {
+  const ctx = useContext(FavoriteSheetContext);
+  if (!ctx)
+    throw new Error(
+      'useFavoriteSheet must be used inside FavoriteSheetProvider',
+    );
+  return ctx;
+};

--- a/front/src/navigations/tab/BottomTabNavigator.tsx
+++ b/front/src/navigations/tab/BottomTabNavigator.tsx
@@ -1,5 +1,5 @@
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
-import {Dimensions, Image} from 'react-native';
+import {Dimensions, Image, Text, TouchableOpacity, View} from 'react-native';
 import MapStackNavigator from '../stack/MapStackNavigator';
 import FavoriteHomeScreen from '../../screens/favorite/FavoriteHomeScreen';
 import MypageHomeScreen from '../../screens/mypage/MypageHomeScreen';
@@ -56,7 +56,46 @@ function BottomTabNavigator() {
         },
       })}>
       <BottomTab.Screen name="홈" component={MapStackNavigator} />
-      <BottomTab.Screen name="즐겨찾기" component={FavoriteHomeScreen} />
+      <BottomTab.Screen
+        name="즐겨찾기"
+        component={MapStackNavigator}
+        options={{
+          tabBarButton: props => {
+            const isFocused = props.accessibilityState?.selected;
+
+            return (
+              <TouchableOpacity
+                {...props}
+                style={{
+                  flex: 1,
+                  justifyContent: 'flex-end',
+                  alignItems: 'center',
+                  paddingBottom: 15,
+                }}
+                onPress={() => globalThis.openFavoriteBottomSheet?.()}>
+                <Image
+                  source={require('../../assets/Favorite.png')}
+                  style={{
+                    width: 24,
+                    height: 24,
+                    tintColor: isFocused ? 'blue' : 'gray',
+                  }}
+                  resizeMode="contain"
+                />
+                <Text
+                  style={{
+                    fontSize: 12,
+                    marginTop: 2,
+                    color: isFocused ? 'blue' : 'gray',
+                  }}>
+                  즐겨찾기
+                </Text>
+              </TouchableOpacity>
+            );
+          },
+        }}
+      />
+
       <BottomTab.Screen name="MY" component={MypageStackNavigator} />
     </BottomTab.Navigator>
   );

--- a/front/src/types/global.d.ts
+++ b/front/src/types/global.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Global {
+    openFavoriteBottomSheet?: () => void;
+  }
+
+  var openFavoriteBottomSheet: () => void;
+}
+
+export {};


### PR DESCRIPTION
## 💡 구현한 기능
- 하단 탭에서 '즐겨찾기' 클릭 시 바텀시트가 올라오도록 처리
- 기존 화면 전환 방식이 아닌, `globalThis.openFavoriteBottomSheet()` 방식으로 처리

## ✅ 주요 변경사항
- BottomTabNavigator.tsx: 즐겨찾기 버튼 커스텀 (TouchableOpacity)
- MapHomeScreen.tsx: 즐겨찾기 바텀시트 상태 및 렌더링 추가
- FavoriteBottomSheetContent.tsx: 즐겨찾기 UI 컴포넌트 구성

## 📌 참고사항
- 즐겨찾기 탭은 화면 전환 없이 바텀시트만 동작합니다
- 탭 포커싱은 따로 적용되지 않습니다

## 🚨 추후 개선 예정
- 즐겨찾기 탭 클릭시 포커싱 되어 색 변환되게 수정 예정
- 즐겨찾기 상태 저장 시 위치 기반 핀 표시
- 아이템 누르면 해당 위치로 이동 기능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a favorites feature allowing users to view and select their favorite locations from a dedicated bottom sheet.
  - Added a custom tab bar button for quick access to the favorites bottom sheet.
  - Selecting a favorite location centers the map on that location.

- **User Interface**
  - Added a new bottom sheet component to display the list of favorite locations.
  - Enhanced tab navigation with a visually distinct favorites tab button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->