### PR TITLE
[fix] 맵 스택 화면 전환 시 탭바 노출 문제 해결

### DIFF
--- a/front/src/navigations/stack/MapStackNavigator.tsx
+++ b/front/src/navigations/stack/MapStackNavigator.tsx
@@ -82,7 +82,7 @@ function MapStackNavigator() {
       <Stack.Screen
         name={mapNavigation.BUILDING_DETAIL}
         component={BuildingDetailScreen}
-        options={{title: '건물 상세정보'}}
+        options={{headerShown: true}}
       />
       <Stack.Screen
         name={mapNavigation.ROUTE_SELECTION}

--- a/front/src/navigations/tab/BottomTabNavigator.tsx
+++ b/front/src/navigations/tab/BottomTabNavigator.tsx
@@ -3,6 +3,8 @@ import {Dimensions, Image, Text, TouchableOpacity} from 'react-native';
 import MapStackNavigator from '../stack/MapStackNavigator';
 import MypageStackNavigator from '../stack/MypageStackNavigator';
 import {defaultTabOptions} from '../../constants/tabOptions';
+import {getFocusedRouteNameFromRoute} from '@react-navigation/native';
+import {mapNavigation} from '../../constants';
 
 const BottomTab = createBottomTabNavigator();
 const deviceHeight = Dimensions.get('screen').height;
@@ -37,7 +39,27 @@ function BottomTabNavigator() {
           );
         },
       })}>
-      <BottomTab.Screen name="홈" component={MapStackNavigator} />
+      <BottomTab.Screen
+        name="홈"
+        component={MapStackNavigator}
+        options={({route}) => {
+          const routeName = getFocusedRouteNameFromRoute(route) ?? '';
+
+          const hiddenScreens = [
+            mapNavigation.SEARCH,
+            mapNavigation.BUILDING_PREVIEW,
+            mapNavigation.BUILDING_DETAIL,
+            mapNavigation.ROUTE_SELECTION,
+            mapNavigation.ROUTE_RESULT,
+          ];
+
+          return {
+            tabBarStyle: hiddenScreens.includes(routeName as any)
+              ? {display: 'none'}
+              : defaultTabOptions.tabBarStyle,
+          };
+        }}
+      />
       <BottomTab.Screen
         name="즐겨찾기"
         component={MapStackNavigator}

--- a/front/src/screens/map/BuildingDetailScreen.tsx
+++ b/front/src/screens/map/BuildingDetailScreen.tsx
@@ -14,7 +14,6 @@ import {mapNavigation} from '../../constants/navigation';
 import buildingApi, {BuildingDetail} from '../../api/buildingApi';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {colors} from '../../constants';
-import {defaultTabOptions} from '../../constants/tabOptions';
 
 const {width: deviceWidth} = Dimensions.get('window');
 
@@ -64,15 +63,6 @@ export default function BuildingDetailScreen() {
       });
     }
   }, [navigation, buildingDetail]);
-
-  useLayoutEffect(() => {
-    const parent = navigation.getParent();
-    parent?.setOptions({tabBarStyle: {display: 'none'}});
-
-    return () => {
-      parent?.setOptions({tabBarStyle: defaultTabOptions.tabBarStyle});
-    };
-  }, [navigation]);
 
   useEffect(() => {
     const id = route.params?.buildingId;

--- a/front/src/screens/map/BuildingPreviewScreen.tsx
+++ b/front/src/screens/map/BuildingPreviewScreen.tsx
@@ -20,7 +20,6 @@ import {mapNavigation} from '../../constants/navigation';
 import {MapStackParamList} from '../../navigations/stack/MapStackNavigator';
 import buildingApi, {BuildingDetail} from '../../api/buildingApi';
 import {StackNavigationProp} from '@react-navigation/stack';
-import {defaultTabOptions} from '../../constants/tabOptions';
 import {colors} from '../../constants';
 
 const deviceWidth = Dimensions.get('screen').width;
@@ -46,7 +45,6 @@ export default function BuildingPreviewScreen() {
   );
   const bottomSheetRef = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => ['55%', '100%'], []);
-  const mapRef = useRef<MapView>(null);
   const mapOffsetLatitude = 0.002;
 
   // 상단 헤더 // 추후에 vector-icon라이브러리로 대체 예정
@@ -74,15 +72,6 @@ export default function BuildingPreviewScreen() {
       });
     }
   }, [navigation, buildingDetail]);
-
-  useLayoutEffect(() => {
-    const parent = navigation.getParent();
-    parent?.setOptions({tabBarStyle: {display: 'none'}});
-
-    return () => {
-      parent?.setOptions({tabBarStyle: defaultTabOptions.tabBarStyle});
-    };
-  }, [navigation]);
 
   useEffect(() => {
     const id = route.params?.buildingId;

--- a/front/src/screens/map/RouteSelectionScreen.tsx
+++ b/front/src/screens/map/RouteSelectionScreen.tsx
@@ -1,10 +1,9 @@
-import React, {useState, useEffect, useLayoutEffect} from 'react';
+import React, {useState, useEffect} from 'react';
 import {View, Text, TouchableOpacity, StyleSheet} from 'react-native';
 import {useNavigation, useRoute, RouteProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {MapStackParamList} from '../../navigations/stack/MapStackNavigator';
 import {mapNavigation} from '../../constants/navigation';
-import {defaultTabOptions} from '../../constants/tabOptions';
 
 type RouteSelectionScreenNavigationProp = StackNavigationProp<
   MapStackParamList,
@@ -18,15 +17,6 @@ type RouteSelectionScreenRouteProp = RouteProp<
 function RouteSelectionScreen() {
   const navigation = useNavigation<RouteSelectionScreenNavigationProp>();
   const route = useRoute<RouteSelectionScreenRouteProp>();
-
-  useLayoutEffect(() => {
-    const parent = navigation.getParent();
-    parent?.setOptions({tabBarStyle: {display: 'none'}});
-
-    return () => {
-      parent?.setOptions({tabBarStyle: defaultTabOptions.tabBarStyle});
-    };
-  }, [navigation]);
 
   const [startLocation, setStartLocation] = useState('');
   const [startLocationName, setStartLocationName] = useState('출발지 선택');

--- a/front/src/screens/map/SearchScreen.tsx
+++ b/front/src/screens/map/SearchScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useLayoutEffect} from 'react';
+import React, {useState} from 'react';
 import {
   View,
   TextInput,
@@ -13,7 +13,6 @@ import {StackNavigationProp} from '@react-navigation/stack';
 import {MapStackParamList} from '../../navigations/stack/MapStackNavigator';
 import {mapNavigation} from '../../constants/navigation';
 import searchApi, {SearchSuggestion} from '../../api/searchApi';
-import {defaultTabOptions} from '../../constants/tabOptions';
 
 type SearchScreenNavigationProp = StackNavigationProp<
   MapStackParamList,
@@ -33,15 +32,6 @@ function SearchScreen() {
   const [searchText, setSearchText] = useState('');
   const [results, setResults] = useState<SearchSuggestion[]>([]);
   const [loading, setLoading] = useState(false);
-
-  useLayoutEffect(() => {
-    const parent = navigation.getParent();
-    parent?.setOptions({tabBarStyle: {display: 'none'}});
-
-    return () => {
-      parent?.setOptions({tabBarStyle: defaultTabOptions.tabBarStyle});
-    };
-  }, [navigation]);
 
   const fetchSuggestions = async (query: string) => {
     if (!query) return;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/buildingInfo` → `develop`

### 변경 사항
- BUILDING_PREVIEW, BUILDING_DETAIL, SEARCH 화면 등에서 하단 탭바가 정상적으로 숨겨지지 않던 이슈 수정
- navigation.getParent()?.setOptions 를 통해 탭바 동적 제어
- replace 방식 그대로 유지하면서도 뒤로가기 및 탭바 동작 정상화

### 테스트 결과
- [x] MapStackNavigator에서 화면전환시 하단 탭바 숨김 및 복구 정상 작동 확인
