### PR TITLE
[fix] 앱 시작 시 자동 로그인 무한 루프 및 토큰 재발급 로직 개선

### DIFF
--- a/front/src/api/axiosInstance.ts
+++ b/front/src/api/axiosInstance.ts
@@ -19,10 +19,31 @@ const skipAuthUrls = [
   '/members/find-password',
 ];
 
-// 요청 인터셉터
+// 토큰 재발급 중 여부를 나타내는 플래그
+let isRefreshing = false;
+// 재발급 중인 동안 대기 중인 요청을 저장하는 큐
+let failedQueue: {
+  resolve: (value?: any) => void;
+  reject: (error: any) => void;
+}[] = [];
+
+// 큐에 대기 중인 요청들을 처리
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach(p => {
+    if (error) {
+      p.reject(error);
+    } else {
+      p.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+// 요청 인터셉터 설정
 axiosInstance.interceptors.request.use(async config => {
   const shouldSkip = skipAuthUrls.some(url => config.url?.includes(url));
 
+  // 인증이 필요한 요청에만 토큰 삽입
   if (!shouldSkip) {
     const token = await EncryptedStorage.getItem('accessToken');
     if (token) {
@@ -31,58 +52,79 @@ axiosInstance.interceptors.request.use(async config => {
   } else {
     delete config.headers.Authorization;
   }
+
   console.log('[axios 요청]', config.method?.toUpperCase(), config.url);
   return config;
 });
 
-// 응답 인터셉터: 재발급 처리
+// 응답 인터셉터 설정
 axiosInstance.interceptors.response.use(
   res => res,
   async error => {
     const originalRequest = error.config;
 
+    // 401 에러이고, 아직 재시도하지 않은 요청이라면
     if (error.response?.status === 401 && !originalRequest._retry) {
+      // 중복 재시도 방지 플래그 설정
       originalRequest._retry = true;
 
+      // 토큰 재발급 중이라면 큐에 요청을 추가하고 대기
+      if (isRefreshing) {
+        try {
+          const newToken = await new Promise((resolve, reject) => {
+            failedQueue.push({resolve, reject});
+          });
+          if (newToken) {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            return axiosInstance(originalRequest);
+          }
+        } catch (err) {
+          return Promise.reject(err);
+        }
+      }
+
+      isRefreshing = true;
+
       try {
+        // 기존 토큰 가져오기
         const accessToken = await EncryptedStorage.getItem('accessToken');
         const refreshToken = await EncryptedStorage.getItem('refreshToken');
-
         if (!accessToken || !refreshToken) throw new Error('토큰 없음');
 
+        // 토큰 재발급 요청
         const res = await requestTokenRefresh(accessToken, refreshToken);
 
+        // 응답 헤더에서 토큰 추출
         const rawAuthHeader =
           res.headers.authorization || res.headers.Authorization;
-        if (!rawAuthHeader || !rawAuthHeader.startsWith('Bearer ')) {
-          throw new Error('유효하지 않은 Authorization 헤더 형식입니다');
-        }
-        const newAccessToken = rawAuthHeader.split(' ')[1];
-        if (!newAccessToken) {
-          throw new Error('Access Token 추출 실패');
-        }
+        const newAccessToken = rawAuthHeader?.split(' ')[1];
         const newRefreshToken = res.headers['x-refresh-token'];
-        if (!newRefreshToken) {
-          throw new Error('Refresh Token 누락');
-        }
-        if (!newAccessToken || !newRefreshToken) throw new Error('재발급 실패');
+        if (!newAccessToken || !newRefreshToken)
+          throw new Error('토큰 재발급 실패');
 
-        // 새 토큰 저장
+        // 새로운 토큰 저장
         await EncryptedStorage.setItem('accessToken', newAccessToken);
         await EncryptedStorage.setItem('refreshToken', newRefreshToken);
 
-        // 재시도 시 헤더 갱신
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        // 큐에 있는 요청들 처리
+        processQueue(null, newAccessToken);
 
+        // 실패했던 요청 재시도
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
       } catch (err) {
-        // 실패 → 로그아웃 처리 (저장소 회원정보 삭제)
+        // 재발급 실패 시 → 로그아웃 처리
+        processQueue(err, null);
         await EncryptedStorage.clear();
-        logoutEmitter.emit('force-logout'); // 전역 로그아웃 이벤트 발생!
+        logoutEmitter.emit('force-logout');
         return Promise.reject(err);
+      } finally {
+        // 재발급 완료
+        isRefreshing = false;
       }
     }
 
+    // 그 외 에러는 그대로 반환
     return Promise.reject(error);
   },
 );

--- a/front/src/navigations/root/Rootnavigator.tsx
+++ b/front/src/navigations/root/Rootnavigator.tsx
@@ -35,44 +35,46 @@ function RootNavigatorContent() {
   useEffect(() => {
     (async () => {
       try {
-        // 저장된 정보 불러오기
-        const userId = await EncryptedStorage.getItem('userId');
-        const role = await EncryptedStorage.getItem('role');
-        const accessToken = await EncryptedStorage.getItem('accessToken');
-        const refreshTokenValue = await EncryptedStorage.getItem(
-          'refreshToken',
-        );
+        const [userId, role, accessToken, refreshTokenValue] =
+          await Promise.all([
+            EncryptedStorage.getItem('userId'),
+            EncryptedStorage.getItem('role'),
+            EncryptedStorage.getItem('accessToken'),
+            EncryptedStorage.getItem('refreshToken'),
+          ]);
 
         if (userId && role && accessToken && refreshTokenValue) {
-          // 앱 시작 시 토큰 무조건 리프레시
           const res = await refreshToken(accessToken, refreshTokenValue);
-          // 응답 헤더에서 새 토큰 추출
           const rawAuth =
             res.headers.authorization || res.headers.Authorization;
           const newAccessToken = rawAuth?.split(' ')[1];
           const newRefreshToken = res.headers['x-refresh-token'];
 
-          if (newAccessToken && newRefreshToken) {
-            await EncryptedStorage.setItem('accessToken', newAccessToken);
-            await EncryptedStorage.setItem('refreshToken', newRefreshToken);
-          } else {
+          if (!newAccessToken || !newRefreshToken) {
             throw new Error('토큰 재발급 실패');
           }
+
+          // 토큰 저장
+          await Promise.all([
+            EncryptedStorage.setItem('accessToken', newAccessToken),
+            EncryptedStorage.setItem('refreshToken', newRefreshToken),
+          ]);
 
           const parsedUserId = parseInt(userId, 10);
           if (isNaN(parsedUserId) || parsedUserId <= 0) {
             throw new Error(`유효하지 않은 userId: ${userId}`);
           }
 
-          // Context에 로그인 처리
-          login({userId: parsedUserId, role: role as 'USER' | 'ADMIN'});
+          // 로그인 상태가 아니라면만 login 호출
+          if (!user) {
+            login({userId: parsedUserId, role: role as 'USER' | 'ADMIN'});
+          }
         }
       } catch (e) {
         console.warn('앱 시작 토큰 리프레시 실패, 로그아웃 처리', e);
         await EncryptedStorage.clear();
         logout();
       } finally {
-        // 복원/리프레시 완료 후 스플래시 숨김
         BootSplash.hide({fade: true});
       }
     })();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/login` → `develop`

### 변경 사항
#### 1. 앱 시작 시 자동 로그인 useEffect 안정화
- 로그인 상태(user 존재)에서도 login()이 호출되며 무한 루프 + 저장소 과다 접근 발생
- 조건 분기로 login 중복 호출 방지하여 무한 루프 방지
- EncryptedStorage 초과 예외 (storage exceeds 196607 properties) 해결

#### 2. axios 응답 인터셉터 개선
- 401 응답 발생 시, 중복된 토큰 재발급 방지 로직 추가 (`isRefreshing`, `failedQueue`)
- 기존에는 여러 요청이 동시에 401을 받을 경우, 재발급 요청이 중복되어 무한 루프 발생
- 개선 후 하나의 재발급 요청만 실행되고, 이후 요청은 큐에 보관 후 일괄 재시도 처리

### 테스트
- 앱 시작 시 토큰 재발급 정상 동작 확인
- 무한 루프 현상 발생하지 않음
- 액세스 토큰 만료 후 자동 재로그인 정상 작동 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * API 요청 중 토큰 만료 시 여러 요청이 동시에 실패하더라도, 토큰 갱신이 한 번만 이루어지고 대기 중인 요청들이 정상적으로 처리되도록 개선되었습니다.
  * 토큰이 누락된 경우 오류가 발생하도록 로직이 수정되었습니다.

* **리팩터링**
  * 사용자 데이터와 토큰을 동시에 불러오고 저장하는 과정이 더 효율적으로 동작하도록 개선되었습니다.
  * 이미 로그인된 경우 중복 로그인 시도를 방지하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->