### PR TITLE
[refactor] validate 함수 유효성 검사 기준 및 오류 메시지 수정

### DIFF
--- a/front/src/screens/auth/FindPw/FindPwScreen.tsx
+++ b/front/src/screens/auth/FindPw/FindPwScreen.tsx
@@ -73,7 +73,7 @@ function FindPwScreen() {
         </View>
         <View style={styles.errorMessageContainer}>
           <CustomText
-            text="영문, 숫자, 특수문자를 포함한 8자리 이상"
+            text="영문, 숫자, 특수문자를 포함한 8~16자리"
             touched={pwconfirmcheak.touched.password}
             error={pwconfirmcheak.errors.password}
           />

--- a/front/src/screens/auth/SignupScreen.tsx
+++ b/front/src/screens/auth/SignupScreen.tsx
@@ -220,7 +220,7 @@ function SignupScreen() {
             </View>
             <View style={styles.errorMessageContainer}>
               <CustomText
-                text="영문, 숫자, 특수문자를 포함한 8자리 이상"
+                text="영문, 숫자, 특수문자를 포함한 8~16자리"
                 touched={signup.touched.password}
                 error={signup.errors.password}
               />

--- a/front/src/utils/validate.ts
+++ b/front/src/utils/validate.ts
@@ -5,7 +5,7 @@ type UserInfomation = {
   email: string;
 };
 
-// 로그인 유효성 검사사
+// 로그인 유효성 검사
 type LoginInfo = Pick<UserInfomation, 'id' | 'password'>;
 
 function validateLogin(values: LoginInfo) {
@@ -14,17 +14,17 @@ function validateLogin(values: LoginInfo) {
     password: '',
   };
 
-  if (!/^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{4,10}$/.test(values.id)) {
-    Loginerrors.id = '아이디는 4~10자의 영문과 숫자를 포함해야 합니다.';
+  if (!/^[a-zA-Z][a-zA-Z0-9]{3,19}$/.test(values.id)) {
+    Loginerrors.id = '아이디는 4~20자의 영문 또는 영문+숫자 조합이어야 합니다.';
   }
 
   if (
-    !/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z\d!@#$%^&*(),.?":{}|<>]{8,}$/.test(
+    !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/.test(
       values.password,
     )
   ) {
     Loginerrors.password =
-      '비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.';
+      '비밀번호는 8~16자이며 영문, 숫자, 특수문자를 포함해야 합니다.';
   }
 
   return Loginerrors;
@@ -40,8 +40,8 @@ function validateId(values: IdInfo) {
     id: '',
   };
 
-  if (!/^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{4,10}$/.test(values.id)) {
-    Iderrors.id = '아이디는 4~10자의 영문과 숫자를 포함해야 합니다.';
+  if (!/^[a-zA-Z][a-zA-Z0-9]{3,19}$/.test(values.id)) {
+    Iderrors.id = '아이디는 4~20자의 영문 또는 영문+숫자 조합이어야 합니다.';
   }
 
   return Iderrors;
@@ -58,12 +58,12 @@ function validatePw(values: PwInfo) {
   };
 
   if (
-    !/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z\d!@#$%^&*(),.?":{}|<>]{8,}$/.test(
+    !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/.test(
       values.password,
     )
   ) {
     Pwerrors.password =
-      '비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.';
+      '비밀번호는 8~16자이며 영문, 숫자, 특수문자를 포함해야 합니다.';
   }
 
   return Pwerrors;
@@ -79,12 +79,12 @@ function validatePwConfirm(values: PwInfo & {passwordConfirm: string}) {
   };
 
   if (
-    !/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z\d!@#$%^&*(),.?":{}|<>]{8,}$/.test(
+    !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/.test(
       values.password,
     )
   ) {
     PwConfirmerrors.password =
-      '비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.';
+      '비밀번호는 8~16자이며 영문, 숫자, 특수문자를 포함해야 합니다.';
   }
 
   if (values.password !== values.passwordConfirm) {
@@ -140,25 +140,29 @@ function validateSignup(
     codemessage: '',
   };
 
-  if (!/^[a-zA-Z가-힣]{2,}$/.test(values.username)) {
+  if (!/^[가-힣a-zA-Z0-9]{2,8}$/.test(values.username)) {
     Signuperrors.username =
-      '사용자 이름은 영어 또는 한글 2자 이상이어야 합니다.';
+      '닉네임은 2~8자의 한글, 영문 또는 숫자여야 하며 특수문자는 사용할 수 없습니다.';
   }
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(values.email)) {
     Signuperrors.email = '올바른 이메일 형식이 아닙니다.';
   }
-  if (!/^(?=.*[a-zA-Z])(?=.*\d)[A-Za-z\d]{4,10}$/.test(values.id)) {
-    Signuperrors.id = '아이디는 4~10자의 영문과 숫자를 포함해야 합니다.';
+
+  if (!/^[a-zA-Z][a-zA-Z0-9]{3,19}$/.test(values.id)) {
+    Signuperrors.id =
+      '아이디는 4~20자의 영문 또는 영문+숫자 조합이어야 합니다.';
   }
+
   if (
-    !/^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[a-zA-Z\d!@#$%^&*(),.?":{}|<>]{8,}$/.test(
+    !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/.test(
       values.password,
     )
   ) {
     Signuperrors.password =
-      '비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 포함해야 합니다.';
+      '비밀번호는 8~16자이며 영문, 숫자, 특수문자를 포함해야 합니다.';
   }
+
   if (values.password !== values.passwordConfirm) {
     Signuperrors.passwordConfirm = '비밀번호가 일치하지 않습니다.';
   }


### PR DESCRIPTION
### PR 타입 (하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/auth` → `develop`

### 변경 사항
- 유효성 검사 정규식 기준 수정
  - **아이디**: 영문 시작 + 영문/숫자 조합, 4~20자
  - **비밀번호**: 영문 + 숫자 + 특수문자 조합, 8~16자
  - **닉네임**: 한글/영문/숫자만 허용, 특수문자 제외, 2~8자
- 각 필드에 대한 오류 메시지 일부 수정


### 테스트 결과
- 회원가입 및 로그인 폼에서 유효성 검사 정상 동작 확인
- 잘못된 입력에 대해 각각 올바른 에러 메시지 노출됨 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비밀번호, 아이디, 닉네임 입력 시 안내 문구 및 유효성 검사 기준이 변경되었습니다.  
    - 비밀번호: 8~16자 영문, 숫자, 특수문자 포함으로 안내 및 검증이 변경되었습니다.
    - 아이디: 4~20자 영문 시작, 영문/숫자 조합으로 안내 및 검증이 변경되었습니다.
    - 닉네임: 2~8자 한글, 영문, 숫자만 허용(특수문자 불가)로 안내 및 검증이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->