### PR TITLE
[feat] 셔틀 위치를 클릭한 정류장으로 이동되도록 수정 및 시간 선택 비활성화

### DIFF
--- a/front/src/components/ShuttleBottomSheetContent.tsx
+++ b/front/src/components/ShuttleBottomSheetContent.tsx
@@ -13,45 +13,42 @@ import {colors} from '../constants';
 
 type Props = {
   data: ShuttleSchedule;
+  currentStopName: string;
 };
 
 const deviceWidth = Dimensions.get('screen').width;
 const deviceHeight = Dimensions.get('screen').height;
 
-const ShuttleBottomSheet = ({data}: Props) => {
-  const [selectedTime, setSelectedTime] = useState(data.nextShuttleTime[0]);
-  const extendedRoute = [...data.route, data.route[0]];
+const ShuttleBottomSheet = ({data, currentStopName}: Props) => {
+  const nearestTime = data.nextShuttleTime[0];
+  const extendedRoute = data.route;
 
   return (
     <View style={styles.container}>
       {/* 시간 선택 */}
       <View style={styles.timeSelector}>
-        {data.nextShuttleTime.map(time => (
-          <TouchableOpacity
-            key={time}
-            style={[
-              styles.timeButton,
-              selectedTime === time && styles.timeButtonActive,
-            ]}
-            onPress={() => setSelectedTime(time)}>
-            <View style={styles.timeButtonContent}>
-              <Image
-                source={require('../assets/category-tabs/shuttle-bus.png')}
-                style={[
-                  styles.busIcon,
-                  selectedTime === time && styles.busIconActive,
-                ]}
-              />
-              <Text
-                style={[
-                  styles.timeButtonText,
-                  selectedTime === time && styles.timeButtonTextActive,
-                ]}>
-                {time}
-              </Text>
+        {data.nextShuttleTime.map(time => {
+          const isNearest = time === nearestTime;
+          return (
+            <View
+              key={time}
+              style={[styles.timeButton, isNearest && styles.timeButtonActive]}>
+              <View style={styles.timeButtonContent}>
+                <Image
+                  source={require('../assets/category-tabs/shuttle-bus.png')}
+                  style={[styles.busIcon, isNearest && styles.busIconActive]}
+                />
+                <Text
+                  style={[
+                    styles.timeButtonText,
+                    isNearest && styles.timeButtonTextActive,
+                  ]}>
+                  {time}
+                </Text>
+              </View>
             </View>
-          </TouchableOpacity>
-        ))}
+          );
+        })}
       </View>
       {/* 노선 타임라인 */}
       <FlatList
@@ -61,27 +58,27 @@ const ShuttleBottomSheet = ({data}: Props) => {
         renderItem={({item, index}) => {
           const isFirst = index === 0;
           const isLast = index === extendedRoute.length - 1;
+          const isCurrentStop = item === currentStopName;
 
           return (
             <View style={styles.routeRow}>
               {/* 타임라인 선 + 점 */}
               <View style={styles.timeline}>
                 {!isFirst && <View style={styles.lineTop} />}
-                {isFirst ? (
+                {isCurrentStop ? (
                   <Image
                     source={require('../assets/category-tabs/shuttle-bus-marker.png')}
                     style={styles.timelineImage}
                   />
                 ) : (
-                  <View
-                    style={[styles.circle, isLast && styles.circleActive]}
-                  />
+                  <View style={styles.circle} />
                 )}
                 {!isLast && <View style={styles.lineBottom} />}
               </View>
               {/* 정류장 이름 */}
               <View style={styles.stopTextWrapper}>
-                <Text style={[styles.stopName, isFirst && styles.departure]}>
+                <Text
+                  style={[styles.stopName, isCurrentStop && styles.departure]}>
                   {item}
                 </Text>
                 {isLast && <Text style={styles.arrival}> 회차</Text>}

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -47,6 +47,7 @@ function MapHomeScreen() {
   const [loadingSchedule, setLoadingSchedule] = useState(false);
   const [showShuttleBottomSheet, setShowShuttleBottomSheet] = useState(false);
   const shuttleSheetRef = useRef<BottomSheet>(null);
+  const [selectedStopName, setSelectedStopName] = useState<string>('');
 
   const mapWebViewRef = useRef<WebView>(null);
   const mapHtmlUrl = `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-home.html?ts=${Date.now()}`;
@@ -79,6 +80,7 @@ function MapHomeScreen() {
         try {
           const res = await fetchShuttleSchedule();
           setShuttleSchedule(res);
+          setSelectedStopName(data.name);
           setShowShuttleBottomSheet(true);
         } catch (err) {
           Alert.alert('오류', '셔틀버스 스케줄을 불러올 수 없습니다.');
@@ -205,17 +207,6 @@ function MapHomeScreen() {
           `}
         />
 
-        <TouchableOpacity
-          style={styles.shortcutButton}
-          onPress={() => navigation.navigate(mapNavigation.SHORTCUT_LIST)}>
-          <Image
-            source={require('../../assets/shortcut-icon.png')}
-            style={{width: 24, height: 24, marginBottom: 4}}
-            resizeMode="contain"
-          />
-          <Text style={styles.shortcutButtonText}>지름길</Text>
-        </TouchableOpacity>
-
         {/* 바텀시트 */}
         {selectedCategory === 'SHUTTLE_BUS' &&
         showShuttleBottomSheet &&
@@ -234,7 +225,10 @@ function MapHomeScreen() {
                 shuttleSheetRef.current?.close();
               }
             }}>
-            <ShuttleBottomSheetContent data={shuttleSchedule} />
+            <ShuttleBottomSheetContent
+              data={shuttleSchedule}
+              currentStopName={selectedStopName}
+            />
           </BottomSheet>
         ) : visible ? (
           <BottomSheet
@@ -295,23 +289,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: colors.GRAY_1000,
     lineHeight: 20,
-  },
-  shortcutButton: {
-    position: 'absolute',
-    bottom: 20,
-    right: 16,
-    width: 56,
-    height: 70,
-    backgroundColor: colors.BLUE_700,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  shortcutButtonText: {
-    color: colors.WHITE,
-    fontSize: 12,
-    fontWeight: '500',
-    marginTop: 2,
   },
 });
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/map-category-marker` → `develop`

## 주요 변경 사항
### 기능 추가
- 셔틀 노선 바텀시트에서 마커 클릭 시 해당 정류장에 셔틀 이미지 및 텍스트가 이동되도록 구현

### 버그 수정
- '인문대 승차' 중복 정류장 제거 (`route` 응답값 내 중복 제거)
- 셔틀 시간탭 클릭 비활성화 처리
- 가장 가까운 시간에만 스타일 강조 적용되도록 수정

### 코드 리팩토링
- `ShuttleBottomSheet`의 타임라인 렌더링 조건문 개선 및 정리
- 불필요한 스타일 조건 분리

### 테스트 결과
- 마커 클릭 시 셔틀 이미지 및 텍스트가 해당 정류장으로 정확히 이동됨
- 시간탭이 클릭되지 않으며, 가장 가까운 시간만 강조됨
- 중복 정류장이 리스트에서 제거되어 1개만 보이는 것 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 셔틀 정류장 선택 시 해당 정류장 이름이 셔틀 하단 시트에 표시됩니다.
  * 가장 가까운 셔틀 시간이 자동으로 강조되어 보여집니다.

* **개선 사항**
  * 셔틀 시간 목록이 더 이상 선택 불가능하며, 버튼 대신 정적인 뷰로 표시됩니다.
  * 노선 타임라인에서 현재 정류장만 동적으로 강조되어 표시됩니다.

* **UI 변경**
  * 셔틀 단축 버튼이 화면에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->