### PR TITLE
[feat] 지름길 기능 API 연동 및 웹뷰사용 스크린/바텀시트 구조 개선, UI 및 주요 버그 수정

### DIFF
--- a/front/src/api/shortcutApi.ts
+++ b/front/src/api/shortcutApi.ts
@@ -1,0 +1,40 @@
+import axios from './axiosInstance';
+
+export interface ShortcutSummary {
+  shortcutId: number;
+  pointA: string;
+  pointB: string;
+  distance: number;
+  duration: number;
+}
+
+export interface ShortcutDetail {
+  shortcutId: number;
+  pointA: string;
+  pointB: string;
+  distance: number;
+  duration: number;
+  coordinates: {
+    latitude: number;
+    longitude: number;
+    pointOrder: number;
+    description: string;
+    turnType: string;
+    segmentDistance: number;
+    imageUrl?: string;
+  }[];
+}
+
+// 지름길 전체 리스트 조회
+export async function fetchShortcuts(): Promise<ShortcutSummary[]> {
+  const res = await axios.get('/shortcuts');
+  return res.data;
+}
+
+// 지름길 상세 조회
+export async function fetchShortcutDetail(
+  shortcutId: number,
+): Promise<ShortcutDetail> {
+  const res = await axios.get(`/shortcuts/${shortcutId}`);
+  return res.data;
+}

--- a/front/src/screens/map/BuildingPreviewScreen.tsx
+++ b/front/src/screens/map/BuildingPreviewScreen.tsx
@@ -27,7 +27,6 @@ import favoriteApi from '../../api/favoriteApi';
 
 const deviceWidth = Dimensions.get('screen').width;
 const deviceHeight = Dimensions.get('window').height;
-const {height: WINDOW_HEIGHT} = Dimensions.get('window');
 
 const facilityIconMap: {[key: string]: any} = {
   엘리베이터: require('../../assets/elevator-icon.png'),
@@ -50,10 +49,12 @@ export default function BuildingPreviewScreen() {
   const [isFavorite, setIsFavorite] = useState(false);
   const bottomSheetRef = useRef<BottomSheet>(null);
 
-  const mapHtmlUrl = `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-preview.html?ts=${Date.now()}`;
+  const mapHtmlUrl = useMemo(
+    () =>
+      `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-preview.html`,
+    [],
+  );
   const mapWebViewRef = useRef<WebView>(null);
-  const [bottomH, setBottomH] = useState(WINDOW_HEIGHT * 0.51);
-
   const [loading, setLoading] = useState(true);
 
   const [startLocation, setStartLocation] = useState('');
@@ -216,8 +217,11 @@ export default function BuildingPreviewScreen() {
           top: 0,
           left: 0,
           right: 0,
-          bottom: bottomH,
+          bottom: deviceHeight * 0.5,
         }}
+        cacheEnabled={true}
+        cacheMode="LOAD_DEFAULT"
+        onLoadEnd={handleMapLoaded}
         injectedJavaScriptBeforeContentLoaded={`
             (function() {
               document.addEventListener("message", function(e) {
@@ -226,13 +230,12 @@ export default function BuildingPreviewScreen() {
             })();
             true;
           `}
-        onLoadEnd={handleMapLoaded}
       />
 
       <BottomSheet
         ref={bottomSheetRef}
         index={0}
-        snapPoints={['55%', '80%']}
+        snapPoints={[deviceHeight * 0.5, '80%']}
         enableContentPanningGesture={true}
         enableHandlePanningGesture={true}
         enableOverDrag={false}

--- a/front/src/screens/map/BuildingPreviewScreen.tsx
+++ b/front/src/screens/map/BuildingPreviewScreen.tsx
@@ -64,6 +64,14 @@ export default function BuildingPreviewScreen() {
   const [endLocationName, setEndLocationName] = useState('');
   const [endBuildingId, setEndBuildingId] = useState<number | undefined>();
 
+  // bottom sheet snap points 계산
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const snapPoints = useMemo(() => {
+    const collapsed = 0.5 * deviceHeight;
+    const expanded = deviceHeight - headerHeight;
+    return [collapsed, expanded];
+  }, [headerHeight]);
+
   useEffect(() => {
     const {
       startLocation,
@@ -235,7 +243,7 @@ export default function BuildingPreviewScreen() {
       <BottomSheet
         ref={bottomSheetRef}
         index={0}
-        snapPoints={[deviceHeight * 0.5, '80%']}
+        snapPoints={snapPoints}
         enableContentPanningGesture={true}
         enableHandlePanningGesture={true}
         enableOverDrag={false}

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {
   View,
   Text,
@@ -50,7 +50,11 @@ function MapHomeScreen() {
   const [selectedStopName, setSelectedStopName] = useState<string>('');
 
   const mapWebViewRef = useRef<WebView>(null);
-  const mapHtmlUrl = `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-home.html?ts=${Date.now()}`;
+  const mapHtmlUrl = useMemo(
+    () =>
+      `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-home.html?ts=${Date.now()}`,
+    [],
+  );
 
   useEffect(() => {
     if (!mapWebViewRef.current) return;

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -50,11 +50,8 @@ function MapHomeScreen() {
   const [selectedStopName, setSelectedStopName] = useState<string>('');
 
   const mapWebViewRef = useRef<WebView>(null);
-  const mapHtmlUrl = useMemo(
-    () =>
-      `https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-home.html?ts=${Date.now()}`,
-    [],
-  );
+  const MAP_HTML_URL =
+    'https://yogiitsu.s3.ap-northeast-2.amazonaws.com/map/map-home.html';
 
   useEffect(() => {
     if (!mapWebViewRef.current) return;
@@ -194,11 +191,13 @@ function MapHomeScreen() {
         {/* 지도 */}
         <WebView
           ref={mapWebViewRef}
-          source={{uri: mapHtmlUrl}}
+          source={{uri: MAP_HTML_URL}}
           originWhitelist={['*']}
           javaScriptEnabled
           domStorageEnabled
           style={{flex: 1}}
+          cacheEnabled={true}
+          cacheMode="LOAD_DEFAULT"
           onLoadEnd={handleWebViewLoad}
           onMessage={handleWebViewMessage}
           injectedJavaScriptBeforeContentLoaded={`

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -207,6 +207,17 @@ function MapHomeScreen() {
           `}
         />
 
+        <TouchableOpacity
+          style={styles.shortcutButton}
+          onPress={() => navigation.navigate(mapNavigation.SHORTCUT_LIST)}>
+          <Image
+            source={require('../../assets/shortcut-icon.png')}
+            style={{width: 24, height: 24, marginBottom: 4}}
+            resizeMode="contain"
+          />
+          <Text style={styles.shortcutButtonText}>지름길</Text>
+        </TouchableOpacity>
+
         {/* 바텀시트 */}
         {selectedCategory === 'SHUTTLE_BUS' &&
         showShuttleBottomSheet &&
@@ -289,6 +300,23 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: colors.GRAY_1000,
     lineHeight: 20,
+  },
+  shortcutButton: {
+    position: 'absolute',
+    bottom: 20,
+    right: 16,
+    width: 56,
+    height: 70,
+    backgroundColor: colors.BLUE_700,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  shortcutButtonText: {
+    color: colors.WHITE,
+    fontSize: 12,
+    fontWeight: '500',
+    marginTop: 2,
   },
 });
 

--- a/front/src/screens/map/ShortcutDetailScreen.tsx
+++ b/front/src/screens/map/ShortcutDetailScreen.tsx
@@ -103,23 +103,48 @@ export default function ShortcutDetailScreen() {
         style={styles.header}
         onLayout={e => setHeaderHeight(e.nativeEvent.layout.height)}>
         <View style={styles.headerTop}>
-          <Text onPress={() => navigation.goBack()} style={styles.iconLeft}>
-            ←
-          </Text>
-          <Image
-            source={require('../../assets/walking-icon.png')}
-            style={styles.walkingIcon}
-          />
-          <Text
-            onPress={() => navigation.navigate(mapNavigation.MAPHOME)}
-            style={styles.iconRight}>
-            ✕
-          </Text>
+          {/* 왼쪽: ← 아이콘 */}
+          <View style={styles.iconWrapper}>
+            <Text onPress={() => navigation.goBack()} style={styles.iconLeft}>
+              ←
+            </Text>
+          </View>
+
+          {/* 중앙: 걷기 아이콘 */}
+          <View style={styles.centerIconWrapper}>
+            <Image
+              source={require('../../assets/walking-icon.png')}
+              style={styles.walkingIcon}
+            />
+          </View>
+
+          {/* 오른쪽: ✕ 아이콘 */}
+          <View style={styles.iconWrapper}>
+            <Text
+              onPress={() => navigation.navigate(mapNavigation.MAPHOME)}
+              style={styles.iconRight}>
+              ✕
+            </Text>
+          </View>
         </View>
         <View style={styles.titleBox}>
-          <Text style={styles.pointText}>{detail?.pointA}</Text>
-          <Text style={styles.arrowIcon}>↔</Text>
-          <Text style={styles.pointText}>{detail?.pointB}</Text>
+          <View style={{flex: 1, alignItems: 'center'}}>
+            <Text
+              style={[styles.pointText, {textAlign: 'center'}]}
+              numberOfLines={1}
+              ellipsizeMode="tail">
+              {detail?.pointA}
+            </Text>
+          </View>
+          <Text style={[styles.arrowIcon, {marginHorizontal: 16}]}>↔</Text>
+          <View style={{flex: 1, alignItems: 'center'}}>
+            <Text
+              style={[styles.pointText, {textAlign: 'center'}]}
+              numberOfLines={1}
+              ellipsizeMode="tail">
+              {detail?.pointB}
+            </Text>
+          </View>
         </View>
       </View>
 
@@ -234,26 +259,40 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingBottom: 20,
   },
+  // headerTop: {
+  //   flexDirection: 'row',
+  //   justifyContent: 'space-between',
+  //   alignItems: 'center',
+  //   position: 'relative',
+  // },
   headerTop: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
     alignItems: 'center',
-    position: 'relative',
+    justifyContent: 'center',
+    // paddingVertical: 5,
+  },
+  iconWrapper: {
+    width: 40, // ←, ✕ 이 들어가는 고정 width
+    alignItems: 'center',
+  },
+  centerIconWrapper: {
+    flex: 1,
+    alignItems: 'center',
   },
   iconLeft: {
     color: 'white',
-    fontSize: 20,
-    textAlign: 'left',
+    fontSize: 22,
+    textAlign: 'center',
+    marginRight: 10,
   },
   iconRight: {
     color: 'white',
-    fontSize: 20,
-    textAlign: 'right',
+    fontSize: 22,
+    textAlign: 'center',
+    marginLeft: 10,
   },
   walkingIcon: {
-    left: '50%',
-    transform: [{translateX: -24}],
-    width: 48,
+    width: 48, // 아이콘 사이즈에 맞게
     height: 30,
   },
   titleBox: {
@@ -264,13 +303,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    columnGap: 70,
     marginTop: 20,
   },
   pointText: {
     color: colors.BLUE_700,
     fontSize: 16,
     fontWeight: '600',
+    paddingHorizontal: 10,
   },
   arrowIcon: {
     color: colors.BLUE_700,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] UI/UX 개선
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/shortcut` → `develop`

## 주요 변경 사항

#### 기능 추가
- 지름길 리스트 진입 버튼 추가
- ShortcutListScreen, ShortcutDetailScreen API 연동 및 기능 구현
- shortcutApi 연결 파일 생성
- 지름길 상세 및 리스트 조회, 경로 안내 기능 완성

#### 리팩토링 및 성능 개선
- mapHtmlUrl, 지도 WebView URI 등 useMemo로 관리하여 불필요한 WebView 리로딩 방지
- WebView 깜빡임 제거 및 캐싱 최적화 (Android cacheEnabled, cacheMode 적용)
- postMessage로 카테고리/즐겨찾기만 갱신하도록 구조 개선
- 바텀시트 높이 deviceHeight 기반 계산 → 퍼센트 단위(`['50%', '80%']`)로 일원화
- BottomSheet snapPoints 동적 계산 및 레이아웃 꼬임 현상 해결

#### 구조/로직 개선
- RouteResultScreen 등 주요 화면의 기능/구조 개선
- 경로 API/건물 상세정보 비동기 로딩 구조 명확화
- 출발/도착지 스왑 로직 개선 및 UI 피드백 추가

#### UI/UX 개선
- 타이틀(출발지/화살표/도착지) 3등분 중앙정렬, 헤더 아이콘(좌/우) 위치 및 정렬 개선
- 걷는 아이콘(walking-icon) 포함 헤더 레이아웃 시각적 완성도 개선
- 각종 상태 관리, 에러 처리, UX 피드백 추가

#### 버그 수정
- BottomSheet snapPoints 픽셀 계산 → 퍼센트 단위로 수정 (navigation 흐름 꼬임까지 유발하던 핵심 원인 해결)
- 스택 꼬임, 레이아웃 꼬임 등 navigation 플로우 문제점 복구

### 테스트 결과
- 모든 메인 플로우(지름길 진입/조회/상세, 지도 전환, 경로 안내 등)에서 정상 동작 확인
- 웹뷰/바텀시트/네비게이션 전환 이슈 없이 일관된 상태 유지 및 UI/UX 개선 적용 완료
