### PR TITLE
[feat] 내 위치 실시간 표시, 지도 마커 필터링 및 부트스플래시 종료 타이밍 개선

### DIFF
--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -95,6 +95,54 @@ function MapHomeScreen() {
   }, []);
 
   useEffect(() => {
+    // 최초 위치 1회 요청
+    Geolocation.getCurrentPosition(
+      position => {
+        const {latitude, longitude} = position.coords;
+        mapWebViewRef.current?.postMessage(
+          JSON.stringify({
+            type: 'setMyLocation',
+            lat: latitude,
+            lng: longitude,
+          }),
+        );
+      },
+      error => {},
+      {enableHighAccuracy: true},
+    );
+  }, []);
+
+  useEffect(() => {
+    const watchId = Geolocation.watchPosition(
+      position => {
+        const {latitude, longitude} = position.coords;
+        mapWebViewRef.current?.postMessage(
+          JSON.stringify({
+            type: 'setMyLocation',
+            lat: latitude,
+            lng: longitude,
+          }),
+        );
+      },
+      error => {
+        console.error(error);
+      },
+      {
+        enableHighAccuracy: true,
+        distanceFilter: 1,
+        interval: 2000,
+        fastestInterval: 1000,
+        showsBackgroundLocationIndicator: false,
+      },
+    );
+
+    // 언마운트시 추적 중지
+    return () => {
+      Geolocation.clearWatch(watchId);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!mapWebViewRef.current) return;
 
     const msg = JSON.stringify({

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -145,15 +145,26 @@ function MapHomeScreen() {
   useEffect(() => {
     if (!mapWebViewRef.current) return;
 
-    const msg = JSON.stringify({
+    const filteredFacilities =
+      selectedCategory && facilities.length > 0
+        ? facilities.filter(f => f.type === selectedCategory)
+        : facilities;
+
+    const msgFacilities = JSON.stringify({
       type: 'setFacilities',
-      data:
-        selectedCategory && facilities.length > 0
-          ? facilities.map(f => ({...f, category: f.type}))
-          : [],
+      data: filteredFacilities.map(f => ({...f, category: f.type})),
     });
 
-    mapWebViewRef.current.postMessage(msg);
+    mapWebViewRef.current.postMessage(msgFacilities);
+
+    // 좌표만 뽑아서 bounds 계산 요청 메시지(예, map 내에 처리 필요)
+    const coords = filteredFacilities.map(f => ({
+      lat: f.latitude,
+      lng: f.longitude,
+    }));
+    mapWebViewRef.current.postMessage(
+      JSON.stringify({type: 'fitBounds', coords}),
+    );
   }, [facilities, selectedCategory]);
 
   const handleWebViewMessage = async (e: any) => {

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -249,6 +249,33 @@ function MapHomeScreen() {
     );
   };
 
+  const moveToMyLocation = async () => {
+    try {
+      const position = await new Promise<Geolocation.GeoPosition>(
+        (resolve, reject) => {
+          Geolocation.getCurrentPosition(
+            pos => resolve(pos),
+            err => reject(err),
+            {enableHighAccuracy: true},
+          );
+        },
+      );
+      const {latitude, longitude} = position.coords;
+      mapWebViewRef.current?.postMessage(
+        JSON.stringify({
+          type: 'moveTo',
+          lat: latitude,
+          lng: longitude,
+        }),
+      );
+    } catch (error) {
+      Alert.alert(
+        '위치 오류',
+        '현재 위치를 불러올 수 없습니다.\n위치 서비스를 확인해주세요.',
+      );
+    }
+  };
+
   const handleSelectFavorite = async (item: FavoriteItem) => {
     try {
       const res = await buildingApi.getBuildingDetail(item.id);
@@ -386,6 +413,15 @@ function MapHomeScreen() {
             true;
           `}
           />
+          <TouchableOpacity
+            style={styles.myLocationButton}
+            onPress={moveToMyLocation}
+            hitSlop={{top: 10, bottom: 10, left: 10, right: 10}}>
+            <Image
+              source={require('../../assets/target-icon.png')} // 아이콘 경로 맞게 변경
+              style={{width: 20, height: 20}}
+            />
+          </TouchableOpacity>
 
           <TouchableOpacity
             style={styles.shortcutButton}
@@ -488,6 +524,18 @@ const styles = StyleSheet.create({
   targetIcon: {
     width: 16,
     height: 16,
+  },
+  myLocationButton: {
+    position: 'absolute',
+    bottom: 30,
+    left: 16,
+    width: 40,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: 'white',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 20,
   },
   shortcutButton: {
     position: 'absolute',

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -148,7 +148,7 @@ function MapHomeScreen() {
     const filteredFacilities =
       selectedCategory && facilities.length > 0
         ? facilities.filter(f => f.type === selectedCategory)
-        : facilities;
+        : [];
 
     const msgFacilities = JSON.stringify({
       type: 'setFacilities',
@@ -157,14 +157,15 @@ function MapHomeScreen() {
 
     mapWebViewRef.current.postMessage(msgFacilities);
 
-    // 좌표만 뽑아서 bounds 계산 요청 메시지(예, map 내에 처리 필요)
-    const coords = filteredFacilities.map(f => ({
-      lat: f.latitude,
-      lng: f.longitude,
-    }));
-    mapWebViewRef.current.postMessage(
-      JSON.stringify({type: 'fitBounds', coords}),
-    );
+    if (selectedCategory) {
+      const coords = filteredFacilities.map(f => ({
+        lat: f.latitude,
+        lng: f.longitude,
+      }));
+      mapWebViewRef.current.postMessage(
+        JSON.stringify({type: 'fitBounds', coords}),
+      );
+    }
   }, [facilities, selectedCategory]);
 
   const handleWebViewMessage = async (e: any) => {

--- a/front/src/screens/map/RouteResultScreen.tsx
+++ b/front/src/screens/map/RouteResultScreen.tsx
@@ -25,6 +25,7 @@ import WebView from 'react-native-webview';
 import AppScreenLayout from '../../components/common/AppScreenLayout';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MAP_RESULT_HTML_URL} from '@env';
+import Geolocation from 'react-native-geolocation-service';
 
 const {height: deviceHeight} = Dimensions.get('window');
 
@@ -88,6 +89,48 @@ function RouteResultScreen() {
       }
     } catch (err) {}
   };
+
+  useEffect(() => {
+    const watchId = Geolocation.watchPosition(
+      position => {
+        const {latitude, longitude} = position.coords;
+        webRef.current?.postMessage(
+          JSON.stringify({
+            type: 'setMyLocation',
+            lat: latitude,
+            lng: longitude,
+          }),
+        );
+      },
+      error => {
+        console.log('위치 추적 에러:', error.code, error.message);
+
+        // 권한 거부(예: error.code === 1) 혹은 기타 오류일 때 안내하기
+        if (error.code === 1) {
+          Alert.alert(
+            '위치 권한 필요',
+            '길찾기 및 위치 기반 서비스를 이용하려면 위치 권한을 허용해주세요.\n설정 > 앱에서 위치 권한을 활성화할 수 있습니다.',
+          );
+        } else {
+          Alert.alert(
+            '위치 오류',
+            '현재 위치를 가져올 수 없습니다. 위치 서비스 설정을 확인해주세요.',
+          );
+        }
+      },
+      {
+        enableHighAccuracy: true,
+        distanceFilter: 1,
+        interval: 2000,
+        fastestInterval: 1000,
+        showsBackgroundLocationIndicator: false,
+      },
+    );
+
+    return () => {
+      Geolocation.clearWatch(watchId);
+    };
+  }, []);
 
   const isLoading = routeLoading || !mapReady;
 

--- a/front/src/screens/map/ShortcutDetailScreen.tsx
+++ b/front/src/screens/map/ShortcutDetailScreen.tsx
@@ -7,6 +7,7 @@ import {
   Image,
   Dimensions,
   TouchableOpacity,
+  Alert,
 } from 'react-native';
 import WebView from 'react-native-webview';
 import BottomSheet from '@gorhom/bottom-sheet';
@@ -19,6 +20,7 @@ import {colors, mapNavigation} from '../../constants';
 import AppScreenLayout from '../../components/common/AppScreenLayout';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {MAP_SHORTCUT_HTML_URL} from '@env';
+import Geolocation from 'react-native-geolocation-service';
 
 type ShortcutDetailRouteProp = RouteProp<
   MapStackParamList,
@@ -102,6 +104,47 @@ export default function ShortcutDetailScreen() {
       ),
     );
   }, [detail, mapReady]);
+
+  useEffect(() => {
+    const watchId = Geolocation.watchPosition(
+      position => {
+        const {latitude, longitude} = position.coords;
+        webRef.current?.postMessage(
+          JSON.stringify({
+            type: 'setMyLocation',
+            lat: latitude,
+            lng: longitude,
+          }),
+        );
+      },
+      error => {
+        console.log('위치 추적 에러:', error.code, error.message);
+
+        // 권한 거부(예: error.code === 1) 혹은 기타 오류일 때 안내하기
+        if (error.code === 1) {
+          Alert.alert(
+            '위치 권한 필요',
+            '길찾기 및 위치 기반 서비스를 이용하려면 위치 권한을 허용해주세요.\n설정 > 앱에서 위치 권한을 활성화할 수 있습니다.',
+          );
+        } else {
+          Alert.alert(
+            '위치 오류',
+            '현재 위치를 가져올 수 없습니다. 위치 서비스 설정을 확인해주세요.',
+          );
+        }
+      },
+      {
+        enableHighAccuracy: true,
+        distanceFilter: 1,
+        interval: 2000,
+        fastestInterval: 1000,
+      },
+    );
+
+    return () => {
+      Geolocation.clearWatch(watchId);
+    };
+  }, []);
 
   const loading = detailLoading || !setMapReady;
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/geolocation` → `develop`

## 변경 사항

### 1. **내 위치 마커 실시간 표시 및 커스텀 아이콘 적용**
- `react-native-geolocation-service`를 이용해 실시간 위치 추적 및 WebView로 위치 정보 전달  
- 카카오맵 웹뷰 내 내 위치 마커 생성 및 위치 이동에 따른 마커 위치 업데이트  
- S3 업로드 커스텀 PNG 아이콘을 마커 이미지로 적용  
- 최초 위치 수신 시에만 지도 중심 이동하여 불필요한 지도 움직임 최소화  

### 2. **길찾기 및 지름길 지도에 현재 위치 마커 추가 및 줌 1회만 적용**
- 길찾기 결과 및 지름길 지도 HTML에 현재 위치 마커 표시 기능 추가  
- 사용자가 직접 지도 줌/이동 시 경로 기준 줌이 계속 강제되는 문제를 수정하여 최초 1회만 줌 레벨 조절  

### 3. **홈 맵 카테고리 선택 시 마커 필터링 및 지도 영역 자동 조절**
- 카테고리별 마커 필터링 및 기존 마커 제거 기능 구현  
- 필터링된 마커가 모두 포함되도록 지도 영역 자동 조절 (`fitBounds` 메시지 활용)  

### 4. **맵홈 화면에 현재 위치로 이동하는 버튼 추가 및 기능 구현**
- 버튼 클릭 시 현재 위치로 즉시 지도 중심 이동  
- 위치 권한 체크 및 위치 수신 로직 개선  

### 5. **버그 수정 및 부트스플래시 종료 타이밍 조정**
- 카테고리 탭 해제 시 지도 자동 바운드 이동 방지  
- 부트스플래시 종료 시점을 현재 위치로 지도 이동 완료 후로 변경  
  - WebView HTML과 React Native 간 메시지 연동 구현  
  - 위치 수신 완료 신호 수신 후 부트스플래시 숨김 처리  
- 위치 권한 요청 및 위치 수신 로직 안정성 강화  

### 6. **기타**
- 부트스플래시 강제 종료 타이머(10초) 추가로 위치 수신 지연 상황 대비  
- 코드 리팩토링 및 불필요 코드 정리 포함  
