### PR TITLE
[feat] 셔틀버스 ETA 지원 및 stopId 기반 조회로 마이그레이션

### DIFF
--- a/front/src/api/facilityApi.ts
+++ b/front/src/api/facilityApi.ts
@@ -7,11 +7,12 @@ export type Facility = {
   buildingId: number;
   type: string;
   id: number;
+  stopId?: string;
 };
 
 export const fetchFacilities = async (type: string): Promise<Facility[]> => {
   const res = await axiosInstance.get('/facilities', {
-    params: {type},
+    params: { type },
   });
   return res.data;
 };

--- a/front/src/api/shuttleApi.ts
+++ b/front/src/api/shuttleApi.ts
@@ -1,12 +1,29 @@
 import axiosInstance from './axiosInstance';
 
-export type ShuttleSchedule = {
-  nextShuttleTime: string[];
-  timeTable: string[];
-  route: string[];
+export type RemainingStop = {
+  stopId: string;
+  stopName: string;
+  estimatedArrivalTime: string;
 };
 
-export const fetchShuttleSchedule = async (): Promise<ShuttleSchedule> => {
-  const res = await axiosInstance.get('/shuttles/schedule');
+export type UpcomingShuttle = {
+  arrivalTimeAtSelectedStop: string;
+  remainingRoute: RemainingStop[];
+};
+
+export type ShuttleSchedule = {
+  selectedStopId: string;
+  selectedStopName: string;
+  upcomingShuttles: UpcomingShuttle[];
+  fullTimeTable: string[];
+  fullRoute: { stopId: string; stopName: string }[];
+};
+
+export const fetchShuttleSchedule = async (
+  stopId: string,
+): Promise<ShuttleSchedule> => {
+  const url = `/shuttles/schedule/${encodeURIComponent(stopId)}`;
+  console.log('[fetchShuttleSchedule] GET', url);
+  const res = await axiosInstance.get(url);
   return res.data;
 };

--- a/front/src/components/ShuttleBottomSheetContent.tsx
+++ b/front/src/components/ShuttleBottomSheetContent.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
@@ -8,81 +8,149 @@ import {
   Dimensions,
   Image,
 } from 'react-native';
-import {ShuttleSchedule} from '../api/shuttleApi';
-import {colors} from '../constants';
+import { ShuttleSchedule } from '../api/shuttleApi';
+import { colors } from '../constants';
 
 type Props = {
   data: ShuttleSchedule;
-  currentStopName: string;
+  currentStopName: string; // 유지 (표시용), phase 계산은 selectedStopId로 처리
 };
 
 const deviceWidth = Dimensions.get('screen').width;
 const deviceHeight = Dimensions.get('screen').height;
 
-const ShuttleBottomSheet = ({data, currentStopName}: Props) => {
-  const nearestTime = data.nextShuttleTime[0];
-  const extendedRoute = data.route;
+const ShuttleBottomSheet = ({ data, currentStopName }: Props) => {
+  // 상단 시간 버튼에서 선택된 셔틀 인덱스
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  // 선택된 셔틀
+  const selected = data.upcomingShuttles?.[selectedIdx];
+
+  // 선택 정류장 이후 구간의 도착예정시간을 stopId -> time 맵으로
+  const arrivalMap = new Map<string, string>(
+    (selected?.remainingRoute ?? []).map(r => [
+      r.stopId,
+      r.estimatedArrivalTime,
+    ]),
+  );
+
+  // 선택 정류장의 인덱스 (전체 노선에서 위치 파악)
+  const selIdx = data.fullRoute.findIndex(
+    r => r.stopId === data.selectedStopId,
+  );
+
+  // 전체 노선 리스트 (fullRoute)를 기반으로 "이전/현재/이후" phase와 시간 머지
+  const mergedRoute = data.fullRoute.map((r, idx) => {
+    const phase =
+      selIdx >= 0
+        ? idx < selIdx
+          ? 'past'
+          : idx === selIdx
+          ? 'current'
+          : 'future'
+        : 'future';
+    return {
+      stopId: r.stopId,
+      stopName: r.stopName,
+      phase, // 'past' | 'current' | 'future'
+      estimatedArrivalTime: arrivalMap.get(r.stopId) ?? null, // 이후 구간(+현재)에만 값이 생김
+    };
+  });
 
   return (
     <View style={styles.container}>
-      {/* 시간 선택 */}
+      {/* 상단: 선택 정류장 도착 예정 시간 목록 */}
       <View style={styles.timeSelector}>
-        {data.nextShuttleTime.map(time => {
-          const isNearest = time === nearestTime;
+        {data.upcomingShuttles.map((s, idx) => {
+          const isActive = idx === selectedIdx;
           return (
-            <View
-              key={time}
-              style={[styles.timeButton, isNearest && styles.timeButtonActive]}>
+            <TouchableOpacity
+              key={s.arrivalTimeAtSelectedStop}
+              activeOpacity={0.8}
+              onPress={() => setSelectedIdx(idx)}
+              style={[styles.timeButton, isActive && styles.timeButtonActive]}
+            >
               <View style={styles.timeButtonContent}>
                 <Image
                   source={require('../assets/category-tabs/shuttle-bus.png')}
-                  style={[styles.busIcon, isNearest && styles.busIconActive]}
+                  style={[styles.busIcon, isActive && styles.busIconActive]}
                 />
                 <Text
                   style={[
                     styles.timeButtonText,
-                    isNearest && styles.timeButtonTextActive,
-                  ]}>
-                  {time}
+                    isActive && styles.timeButtonTextActive,
+                  ]}
+                >
+                  {s.arrivalTimeAtSelectedStop}
                 </Text>
               </View>
-            </View>
+            </TouchableOpacity>
           );
         })}
       </View>
-      <Text style={styles.message}>* 위의 시간은 인문대 승차시간 기준</Text>
-      {/* 노선 타임라인 */}
+      <Text style={styles.message}>
+        * 도착 예정시간은 실시간이 아닌 예상 시간
+      </Text>
+
+      {/* 전체 노선 타임라인 (이전·현재·이후 모두 표시) */}
       <FlatList
-        data={extendedRoute}
-        keyExtractor={(item, index) => `${index}-${item}`}
-        contentContainerStyle={{paddingTop: 12}}
-        renderItem={({item, index}) => {
+        data={mergedRoute}
+        keyExtractor={(item, index) => `${index}-${item.stopId}`}
+        contentContainerStyle={{ paddingTop: 12 }}
+        renderItem={({ item, index }) => {
           const isFirst = index === 0;
-          const isLast = index === extendedRoute.length - 1;
-          const isCurrentStop = item === currentStopName;
+          const isLast = index === mergedRoute.length - 1;
+          const isPast = item.phase === 'past';
+          const isCurrent = item.phase === 'current';
+          const isFuture = item.phase === 'future';
 
           return (
             <View style={styles.routeRow}>
               {/* 타임라인 선 + 점 */}
               <View style={styles.timeline}>
-                {!isFirst && <View style={styles.lineTop} />}
-                {isCurrentStop ? (
+                {!isFirst && (
+                  <View
+                    style={[
+                      styles.lineTop,
+                      isPast && styles.dimmed, // 지난 구간 희미하게
+                    ]}
+                  />
+                )}
+                {isCurrent ? (
                   <Image
                     source={require('../assets/category-tabs/shuttle-bus-marker.png')}
                     style={styles.timelineImage}
                   />
                 ) : (
-                  <View style={styles.circle} />
+                  <View
+                    style={[
+                      styles.circle,
+                      isPast && styles.dimmed, // 지난 구간 점도 희미하게
+                    ]}
+                  />
                 )}
-                {!isLast && <View style={styles.lineBottom} />}
+                {!isLast && (
+                  <View style={[styles.lineBottom, isPast && styles.dimmed]} />
+                )}
               </View>
-              {/* 정류장 이름 */}
+
+              {/* 정류장명 + (이후/현재 구간만) 예측 시간 */}
               <View style={styles.stopTextWrapper}>
                 <Text
-                  style={[styles.stopName, isCurrentStop && styles.departure]}>
-                  {item}
+                  style={[
+                    styles.stopName,
+                    isCurrent && styles.departure,
+                    isPast && styles.pastStopText,
+                  ]}
+                >
+                  {item.stopName}
                 </Text>
-                {isLast && <Text style={styles.arrival}> 회차</Text>}
+
+                {(isFuture || isCurrent) && item.estimatedArrivalTime ? (
+                  <Text style={styles.arrivalTime}>
+                    {item.estimatedArrivalTime} 도착 예정
+                  </Text>
+                ) : null}
               </View>
             </View>
           );
@@ -101,15 +169,16 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
   container: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 40,
   },
   timeSelector: {
     flexDirection: 'row',
     justifyContent: 'flex-start',
-    marginBottom: 10,
+    marginBottom: 12,
     gap: 12,
+    flexWrap: 'wrap',
   },
   timeButton: {
     paddingHorizontal: 14,
@@ -190,9 +259,6 @@ const styles = StyleSheet.create({
     borderColor: colors.GRAY_450,
     backgroundColor: 'white',
   },
-  circleActive: {
-    borderColor: colors.BLUE_700,
-  },
   stopTextWrapper: {
     flexDirection: 'row',
     alignItems: 'baseline',
@@ -208,11 +274,24 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     color: colors.BLACK_900,
   },
+  pastStopText: {
+    color: '#9AA0A6',
+  },
+  dimmed: {
+    opacity: 0.4,
+  },
   arrival: {
     marginLeft: 7,
     fontSize: 12,
     fontWeight: '500',
     color: colors.GRAY_500,
+  },
+  arrivalTime: {
+    marginLeft: 8,
+    fontSize: 10,
+    color: colors.GRAY_500,
+    fontWeight: '500',
+    lineHeight: 14,
   },
 });
 

--- a/front/src/screens/map/ShuttleDetailScreen.tsx
+++ b/front/src/screens/map/ShuttleDetailScreen.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {View, Text, StyleSheet, Image, ScrollView} from 'react-native';
-import {useRoute, RouteProp} from '@react-navigation/native';
-import {MapStackParamList} from '../../navigations/stack/MapStackNavigator';
-import {mapNavigation} from '../../constants/navigation';
-import {colors} from '../../constants';
+import { View, Text, StyleSheet, Image, ScrollView } from 'react-native';
+import { useRoute, RouteProp } from '@react-navigation/native';
+import { MapStackParamList } from '../../navigations/stack/MapStackNavigator';
+import { mapNavigation } from '../../constants/navigation';
+import { colors } from '../../constants';
 import AppScreenLayout from '../../components/common/AppScreenLayout';
 
 type RouteParams = RouteProp<
@@ -13,14 +13,52 @@ type RouteParams = RouteProp<
 
 const ShuttleDetailScreen = () => {
   const route = useRoute<RouteParams>();
-  const {shuttleSchedule, selectedTime, currentStopName} = route.params;
+  const { shuttleSchedule, selectedTime, currentStopName } = route.params;
 
-  // 2열 그리드 데이터 변환
+  // ================== 상단 시간표 (2열 그리드) ==================
   const timeTableRows: (string | null)[][] = [];
-  const {timeTable, route: routeList} = shuttleSchedule;
-  for (let i = 0; i < timeTable.length; i += 2) {
-    timeTableRows.push([timeTable[i], timeTable[i + 1] ?? null]);
+  const fullTimeTable: string[] = shuttleSchedule.fullTimeTable ?? [];
+  for (let i = 0; i < fullTimeTable.length; i += 2) {
+    timeTableRows.push([fullTimeTable[i], fullTimeTable[i + 1] ?? null]);
   }
+
+  // ================== 노선 타임라인 (전체 + 예상시간 머지) ==================
+  // 선택된 시간대의 셔틀(없으면 첫 번째)에서 remainingRoute를 꺼낸다
+  const selectedShuttle =
+    shuttleSchedule.upcomingShuttles?.find(
+      s => s.arrivalTimeAtSelectedStop === selectedTime,
+    ) ?? shuttleSchedule.upcomingShuttles?.[0];
+
+  // 이후 구간(선택 정류장 포함)의 도착예정 시간을 맵으로 (stopId -> time)
+  const arrivalMap = new Map<string, string>(
+    (selectedShuttle?.remainingRoute ?? []).map(r => [
+      r.stopId,
+      r.estimatedArrivalTime,
+    ]),
+  );
+
+  // 선택 정류장의 인덱스
+  const selIdx = shuttleSchedule.fullRoute.findIndex(
+    r => r.stopId === shuttleSchedule.selectedStopId,
+  );
+
+  // 전체 노선을 기준으로 이전/현재/이후 phase 및 시간 머지
+  const mergedRoute = shuttleSchedule.fullRoute.map((r, idx) => {
+    const phase =
+      selIdx >= 0
+        ? idx < selIdx
+          ? 'past'
+          : idx === selIdx
+          ? 'current'
+          : 'future'
+        : 'future';
+    return {
+      stopId: r.stopId,
+      stopName: r.stopName,
+      phase, // 'past' | 'current' | 'future'
+      estimatedArrivalTime: arrivalMap.get(r.stopId) ?? null, // 이후/현재만 값 존재
+    };
+  });
 
   return (
     <AppScreenLayout disableTopInset>
@@ -30,10 +68,11 @@ const ShuttleDetailScreen = () => {
           <View style={styles.timeHeader}>
             <Text style={styles.sectionTitle}>운행 시간표</Text>
             <Text style={styles.noticeText}>
-              * 각 시간별로 인문대 앞에서 출발
+              * 도착 예정시간은 실시간이 아닌 예상 시간
             </Text>
           </View>
-          {/* 시간표 그리드 */}
+
+          {/* 시간표 그리드 (2열) */}
           <View style={styles.timeTable}>
             {timeTableRows.map((row, i) => (
               <View style={styles.timeRow} key={i}>
@@ -44,7 +83,8 @@ const ShuttleDetailScreen = () => {
                       style={[
                         styles.timeCell,
                         time === selectedTime && styles.timeCellActive,
-                      ]}>
+                      ]}
+                    >
                       <View style={styles.timeCellContent}>
                         {time === selectedTime && (
                           <Image
@@ -56,44 +96,70 @@ const ShuttleDetailScreen = () => {
                           style={[
                             styles.timeText,
                             time === selectedTime && styles.timeTextActive,
-                          ]}>
+                          ]}
+                        >
                           {time}
                         </Text>
                       </View>
                     </View>
                   ) : (
-                    <View style={[styles.timeCell, {opacity: 0}]} key={j} />
+                    <View style={[styles.timeCell, { opacity: 0 }]} key={j} />
                   ),
                 )}
               </View>
             ))}
           </View>
-          {/* 승차장/노선 타임라인 */}
+
+          {/* 승차장/노선 타임라인 (전체 표시 + 이후 구간만 시간 표기) */}
           <Text style={styles.stationTitle}>승차장</Text>
           <View style={styles.routeList}>
-            {routeList.map((item, index) => {
-              const isCurrent = item === currentStopName;
+            {mergedRoute.map((item, index) => {
               const isFirst = index === 0;
-              const isLast = index === routeList.length - 1;
+              const isLast = index === mergedRoute.length - 1;
+              const isCurrent = item.phase === 'current';
+              const isPast = item.phase === 'past';
+
               return (
-                <View style={styles.routeRow} key={item + index}>
+                <View style={styles.routeRow} key={`${item.stopId}-${index}`}>
                   <View style={styles.timeline}>
-                    {!isFirst && <View style={styles.lineTop} />}
+                    {!isFirst && (
+                      <View style={[styles.lineTop, isPast && styles.dimmed]} />
+                    )}
                     {isCurrent ? (
                       <Image
                         source={require('../../assets/category-tabs/shuttle-bus-marker.png')}
                         style={styles.timelineImage}
                       />
                     ) : (
-                      <View style={styles.circle} />
+                      <View style={[styles.circle, isPast && styles.dimmed]} />
                     )}
-                    {!isLast && <View style={styles.lineBottom} />}
+                    {!isLast && (
+                      <View
+                        style={[styles.lineBottom, isPast && styles.dimmed]}
+                      />
+                    )}
                   </View>
-                  <Text
-                    style={[styles.stopName, isCurrent && styles.departure]}>
-                    {item}
-                    {isLast && <Text style={styles.arrival}> 회차</Text>}
-                  </Text>
+
+                  <View style={styles.stopTextRow}>
+                    <Text
+                      style={[
+                        styles.stopName,
+                        isCurrent && styles.departure,
+                        isPast && styles.pastStopText,
+                      ]}
+                    >
+                      {item.stopName}
+                      {isLast && <Text style={styles.arrival}> 회차</Text>}
+                    </Text>
+
+                    {/* 현재/이후 구간에만 예측 시간 표기 */}
+                    {(item.phase === 'current' || item.phase === 'future') &&
+                      item.estimatedArrivalTime && (
+                        <Text style={styles.arrivalTime}>
+                          {item.estimatedArrivalTime} 도착 예정
+                        </Text>
+                      )}
+                  </View>
                 </View>
               );
             })}
@@ -105,11 +171,11 @@ const ShuttleDetailScreen = () => {
 };
 
 const styles = StyleSheet.create({
-  scrollContent: {flexGrow: 1},
+  scrollContent: { flexGrow: 1 },
   container: {
     flex: 1,
     backgroundColor: 'white',
-    paddingHorizontal: 20,
+    paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 24,
   },
@@ -178,7 +244,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   routeList: {
-    // paddingHorizontal: 8,
     paddingTop: 2,
     paddingBottom: 10,
   },
@@ -227,6 +292,10 @@ const styles = StyleSheet.create({
     borderColor: colors.GRAY_450,
     backgroundColor: 'white',
   },
+  stopTextRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+  },
   stopName: {
     fontSize: 14,
     marginLeft: 14,
@@ -238,11 +307,24 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: colors.BLACK_900,
   },
+  pastStopText: {
+    color: '#9AA0A6',
+  },
+  dimmed: {
+    opacity: 0.4,
+  },
   arrival: {
     marginLeft: 7,
     fontSize: 12,
     fontWeight: '500',
     color: colors.GRAY_500,
+  },
+  arrivalTime: {
+    marginLeft: 8,
+    fontSize: 10,
+    color: colors.GRAY_500,
+    fontWeight: '500',
+    lineHeight: 14,
   },
 });
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/shuttle-bus` → `develop`

### 배경
- 정류장별 **예상도착시간(ETA)** 를 제공하기 위해 스케줄 API가 개편됨.
- 정류장 식별은 name가 아닌 **stopId** 기준으로 조회.

### 변경 사항
- **API**
  - `GET /shuttles/schedule/{stopId}` 사용.
  - 응답 스키마: `selectedStopId/selectedStopName`, `upcomingShuttles[].arrivalTimeAtSelectedStop`, `upcomingShuttles[].remainingRoute[{ stopId, stopName, estimatedArrivalTime }]`, `fullTimeTable`, `fullRoute[{stopId, stopName}]`.
- **연동**
  - WebView로 내려보내는 facilities에 `stopId` 포함(초기/필터 모두).
  - name/id 폴백 제거, `stopId` 누락 시 호출 중단.
- **UI**
  - 바텀시트: `fullRoute` 전체 표시 + **ETA 머지**, 상단 시간칩은 보기 전용(가장 가까운 시간 강조).
  - 상세: `fullTimeTable/fullRoute` 반영, `selectedTime` 하이라이트 + ETA 병합.

### 테스트 결과
- 정류장 마커 클릭 시 stopId로 정상 호출 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 셔틀 정보를 정류장 중심으로 제공하고, 정류장별 도착 예정 시간을 표시합니다.
  - 셔틀 시트/상세 화면에 시간 선택 칩과 노선 타임라인을 도입해 정류장 상태(지난/현재/다음)를 시각화합니다.
  - 지도에서 시설-정류장 매핑으로 정류장 정보를 함께 전달합니다.
- Bug Fixes
  - 정류장 정보 없이 셔틀 호출 시 경고 후 중단해 오류를 방지합니다.
- Refactor
  - 시간표/노선 데이터 구조를 일원화하고, 딥링크 건물 프리뷰와 필터 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->