### PR TITLE
[feat] 업데이트 모달 API 연동 및 UI 개선

### DIFF
--- a/front/App.tsx
+++ b/front/App.tsx
@@ -12,13 +12,17 @@ function App() {
   return (
     <SafeAreaProvider>
       <AppInitProvider>
-        {/* <VersionGate
+        <VersionGate
           fallbackConfig={{
-            latestVersion: '2.3.8', // 배포하는 버전명
+            latestVersion: '2.3.8',
+            minSupportedVersion: '2.3.6',
           }}
-          snoozeHours={24}
+          defaultMessage={`안정적인 서비스 이용을 위해\n최신 버전으로 업데이트 해주세요.`}
+          iosAppStoreId={undefined}
+          // iosAppStoreId="1234567890" // ios배포시 등록하기
           aggressive={true}
-        /> */}
+          snoozeHours={24}
+        />
         <NavigationContainer>
           <Rootnavigator />
         </NavigationContainer>

--- a/front/src/api/versionApi.ts
+++ b/front/src/api/versionApi.ts
@@ -1,0 +1,78 @@
+// src/api/versionApi.ts
+import axiosInstance from './axiosInstance';
+import DeviceInfo from 'react-native-device-info';
+import { Platform } from 'react-native';
+
+export type ServerUpdateType = 'NONE' | 'SELECT' | 'FORCE';
+export type ClientUpdateType = 'NONE' | 'SOFT' | 'HARD';
+
+export type ServerVersionPolicy = {
+  updateType?: ServerUpdateType | string; // 서버 원본 (혹시 모를 변형 대비)
+  latestVersion?: string;
+  minVersion?: string;
+  // message?: string;
+  storeUrl?: string;
+};
+
+export type ClientVersionPolicy = {
+  updateType: ClientUpdateType;
+  latestVersion?: string;
+  minVersion?: string;
+  // message?: string;
+  storeUrl?: string;
+};
+
+function cmpSemver(a?: string, b?: string) {
+  if (!a || !b) return 0;
+  const A = a.split('.').map(Number),
+    B = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(A.length, B.length); i++) {
+    const d = (A[i] || 0) - (B[i] || 0);
+    if (d) return d > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+// 서버 타입 → 클라 공통 타입 정규화
+function normalizeType(serverType?: string): ClientUpdateType | undefined {
+  const t = (serverType || '').toUpperCase();
+  if (t === 'NONE') return 'NONE';
+  if (t === 'SELECT' || t === 'SOFT' || t === 'OPTIONAL' || t === 'RECOMMEND')
+    return 'SOFT';
+  if (t === 'FORCE' || t === 'HARD' || t === 'MANDATORY' || t === 'REQUIRED')
+    return 'HARD';
+  return undefined; // 모르는 값이면 undefined로 반환 → 아래 보정 로직으로 처리
+}
+
+export async function fetchVersionPolicy(): Promise<ClientVersionPolicy> {
+  const currentVersion = DeviceInfo.getVersion();
+  const platform = Platform.OS === 'ios' ? 'IOS' : 'ANDROID';
+
+  const { data } = await axiosInstance.get<ServerVersionPolicy>(
+    '/app/version',
+    {
+      params: { platform, currentVersion },
+    },
+  );
+
+  const latest = data.latestVersion;
+  const min = data.minVersion;
+
+  // 1) 우선 타입 정규화
+  let type = normalizeType(data.updateType);
+
+  // 2) 혹시 모르면 버전 비교로 보정 (서버 타입이 비표준일 때 안전망)
+  if (!type) {
+    if (min && cmpSemver(currentVersion, min) < 0) type = 'HARD';
+    else if (latest && cmpSemver(currentVersion, latest) < 0) type = 'SOFT';
+    else type = 'NONE';
+  }
+
+  return {
+    updateType: type,
+    latestVersion: latest,
+    minVersion: min,
+    // message: data.message,
+    storeUrl: data.storeUrl,
+  };
+}

--- a/front/src/components/common/VersionGate.tsx
+++ b/front/src/components/common/VersionGate.tsx
@@ -7,10 +7,12 @@ import {
   BackHandler,
   Linking,
   Platform,
+  Image,
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import { fetchVersionPolicy } from '../../api/versionApi';
+import { colors } from '../../constants';
 
 type RemoteConfig = {
   minSupportedVersion?: string; // fallback 강제 기준(미만이면 HARD)
@@ -112,7 +114,7 @@ export default function VersionGate({
 
       // 1) 서버 정책 우선
       try {
-        const policy = await fetchVersionPolicy(); // updateType: 'NONE' | 'SOFT' | 'HARD' 로 정규화되어 있다고 가정
+        const policy = await fetchVersionPolicy();
         type = policy.updateType;
 
         // latest/storeUrl 업데이트 (message는 서버가 절대 안 주므로 프론트 고정 유지)
@@ -142,8 +144,6 @@ export default function VersionGate({
         setShow(true);
       }
     })();
-    // latest를 의존성에서 제거하여 setLatest 후 반복 호출 방지
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     aggressive,
     fallbackConfig,
@@ -184,55 +184,110 @@ export default function VersionGate({
           backgroundColor: 'rgba(0,0,0,0.6)',
           alignItems: 'center',
           justifyContent: 'center',
-          padding: 20,
+          padding: 25,
         }}
       >
         <View
           style={{
             backgroundColor: '#fff',
-            borderRadius: 16,
-            padding: 20,
+            borderRadius: 6,
+            padding: 24,
             width: '100%',
             maxWidth: 420,
             alignItems: 'center',
           }}
         >
-          <Text style={{ fontSize: 18, fontWeight: '700', marginBottom: 14 }}>
+          {hard ? (
+            <Image
+              source={require('../../assets/Warning-icon-blue.png')}
+              style={{ width: 28, height: 28, marginBottom: 18 }}
+            />
+          ) : (
+            <Image
+              source={require('../../assets/Warning-icon-gray.png')}
+              style={{ width: 28, height: 28, marginBottom: 18 }}
+            />
+          )}
+
+          {/* 제목 */}
+          <Text
+            style={{
+              color: colors.BLACK_700,
+              fontSize: 18,
+              fontWeight: '600',
+              marginBottom: 13,
+            }}
+          >
             {hard ? '업데이트 필요' : '업데이트 권장'}
           </Text>
+
+          {/* 메시지 */}
           <Text
             style={{
               fontSize: 14,
-              color: '#444',
-              marginBottom: 16,
+              color: '#999',
+              fontWeight: '600',
+              marginBottom: 30,
               textAlign: 'center',
+              lineHeight: 20,
             }}
           >
             {message}
           </Text>
 
-          <TouchableOpacity
-            onPress={onUpdate}
-            style={{ paddingVertical: 10, paddingHorizontal: 14 }}
-          >
-            <Text style={{ fontWeight: '700' }}>스토어로 이동</Text>
-          </TouchableOpacity>
-
-          {!hard && (
-            <>
+          {/* 버튼 영역 */}
+          {hard ? (
+            // HARD 모드
+            <TouchableOpacity
+              onPress={onUpdate}
+              style={{
+                backgroundColor: colors.BLUE_700,
+                borderRadius: 8,
+                paddingVertical: 16,
+                paddingHorizontal: 20,
+                width: '100%',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Text style={{ color: '#fff', fontWeight: '600' }}>
+                스토어로 이동
+              </Text>
+            </TouchableOpacity>
+          ) : (
+            // SOFT 모드
+            <View style={{ flexDirection: 'row', width: '100%' }}>
               <TouchableOpacity
                 onPress={onLater}
-                style={{ paddingVertical: 10, paddingHorizontal: 14 }}
+                style={{
+                  flex: 1,
+                  backgroundColor: colors.GRAY_700,
+                  borderRadius: 6,
+                  paddingVertical: 16,
+                  marginRight: 8,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
               >
-                <Text>나중에</Text>
+                <Text style={{ color: '#fff', fontWeight: '600' }}>나중에</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                onPress={onCloseThisVersion}
-                style={{ paddingVertical: 10, paddingHorizontal: 14 }}
+                onPress={onUpdate}
+                style={{
+                  flex: 1,
+                  backgroundColor: colors.BLUE_700,
+                  borderRadius: 8,
+                  paddingVertical: 12,
+                  marginLeft: 8,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
               >
-                <Text>닫기</Text>
+                <Text style={{ color: '#fff', fontWeight: '700' }}>
+                  스토어로 이동
+                </Text>
               </TouchableOpacity>
-            </>
+            </View>
           )}
         </View>
       </View>

--- a/front/src/components/common/VersionGate.tsx
+++ b/front/src/components/common/VersionGate.tsx
@@ -1,4 +1,3 @@
-// src/components/common/VersionGate.tsx
 import React, { useEffect, useState } from 'react';
 import {
   Modal,
@@ -6,128 +5,173 @@ import {
   Text,
   TouchableOpacity,
   BackHandler,
-  Platform,
   Linking,
+  Platform,
 } from 'react-native';
 import DeviceInfo from 'react-native-device-info';
 import EncryptedStorage from 'react-native-encrypted-storage';
+import { fetchVersionPolicy } from '../../api/versionApi';
 
 type RemoteConfig = {
-  minSupportedVersion?: string;
-  latestVersion: string;
-  updateUrl?: string;
-  message?: string;
+  minSupportedVersion?: string; // fallback 강제 기준(미만이면 HARD)
+  latestVersion: string; // fallback 권장 기준(미만이면 SOFT)
+  updateUrl?: string; // 서버/프론트에서 스토어 URL 직접 지정 시 사용 가능
 };
 
 type Props = {
   fallbackConfig: RemoteConfig;
-  snoozeHours?: number; // "나중에" 눌렀을 때 재알림까지 시간
-  aggressive?: boolean; // true면 시작 때마다(스누즈 제외) 계속 알림
+  snoozeHours?: number; // SOFT일 때 “나중에” 숨김 시간
+  aggressive?: boolean; // false면 동일 latest에 대해 “닫기” 기억
+  defaultMessage?: string; // 서버에서 message 안 줄 때 사용할 고정 문구
+  iosAppStoreId?: string; // iOS App Store ID (없으면 앱스토어 메인으로)
+  androidPackageName?: string; // 안드로이드 패키지명(없으면 현재 번들ID)
 };
 
 const SNOOZE_KEY = 'version_gate_snooze_until';
 const DISMISS_KEY_PREFIX = 'version_gate_dismissed_';
+const DEFAULT_MESSAGE =
+  '안정적인 서비스 이용을 위해 최신 버전으로 업데이트 해주세요.';
 
-// --- Android 전용 스토어 링크 도우미 ---
-function getAndroidPlayUrl() {
-  const pkg = DeviceInfo.getBundleId();
-  return __DEV__
-    ? `https://play.google.com/store/apps/details?id=${pkg}` // 에뮬/테스트
-    : `market://details?id=${pkg}`; // 실기기(스토어 앱)
-}
-
-async function openStore(updateUrl?: string) {
-  const target = updateUrl || getAndroidPlayUrl();
-  const can = await Linking.canOpenURL(target);
-  if (!can && target.startsWith('market://')) {
-    const pkg = DeviceInfo.getBundleId();
-    return Linking.openURL(
-      `https://play.google.com/store/apps/details?id=${pkg}`,
-    );
-  }
-  return Linking.openURL(target);
-}
-
-// --- 버전 비교 ---
-function cmp(a: string, b: string) {
-  const A = a.split('.').map(Number),
-    B = b.split('.').map(Number);
+// semver 비교: a<b → -1, a=b → 0, a>b → 1
+const cmp = (a: string, b: string) => {
+  const A = a.split('.').map(Number);
+  const B = b.split('.').map(Number);
   for (let i = 0; i < Math.max(A.length, B.length); i++) {
     const d = (A[i] || 0) - (B[i] || 0);
     if (d) return d > 0 ? 1 : -1;
   }
   return 0;
-}
+};
+
+// 스토어 URL 유틸
+const getAndroidPlayUrl = (pkg?: string) =>
+  `https://play.google.com/store/apps/details?id=${
+    pkg || DeviceInfo.getBundleId()
+  }`;
+
+const getIosAppStoreUrl = (appId?: string) =>
+  appId
+    ? `itms-apps://itunes.apple.com/app/id${appId}`
+    : `https://apps.apple.com/`;
+
+const getIosAppStoreHttps = (appId?: string) =>
+  appId ? `https://apps.apple.com/app/id${appId}` : `https://apps.apple.com/`;
 
 export default function VersionGate({
   fallbackConfig,
   snoozeHours = 24,
   aggressive = true,
+  defaultMessage,
+  iosAppStoreId,
+  androidPackageName,
 }: Props) {
   const [show, setShow] = useState(false);
-  const [must, setMust] = useState(false);
-  const [conf, setConf] = useState<RemoteConfig>(fallbackConfig);
+  const [hard, setHard] = useState(false);
+  const [message, setMessage] = useState<string>(
+    defaultMessage ?? DEFAULT_MESSAGE,
+  );
+  const [storeUrl, setStoreUrl] = useState<string | undefined>();
+  const [latest, setLatest] = useState<string | undefined>(
+    fallbackConfig.latestVersion,
+  );
+
+  // 플랫폼별 스토어 열기
+  const openStore = async (updateUrl?: string) => {
+    let target = updateUrl;
+
+    if (!target) {
+      if (Platform.OS === 'ios') {
+        target = getIosAppStoreUrl(iosAppStoreId);
+      } else {
+        target = getAndroidPlayUrl(androidPackageName);
+      }
+    }
+
+    let can = await Linking.canOpenURL(target);
+    if (!can) {
+      // iOS: itms-apps를 못 여는 환경(시뮬레이터 등)은 https로 폴백
+      if (Platform.OS === 'ios' && target.startsWith('itms-apps://')) {
+        target = getIosAppStoreHttps(iosAppStoreId);
+        can = await Linking.canOpenURL(target);
+      }
+      // Android: market 스킴을 쓰지 않지만 혹시 실패하면 https로 폴백
+      if (!can && Platform.OS !== 'ios') {
+        target = getAndroidPlayUrl(androidPackageName);
+      }
+    }
+    return Linking.openURL(target);
+  };
 
   useEffect(() => {
     (async () => {
-      // 스누즈 확인
+      // 0) 스누즈 체크 (SOFT에서만 적용)
       const until = await EncryptedStorage.getItem(SNOOZE_KEY);
       if (until && Number(until) > Date.now()) return;
 
-      // (이번엔 원격 JSON 없이 fallback만 사용)
-      const current = DeviceInfo.getVersion();
-      const latest = conf.latestVersion;
-      const min = conf.minSupportedVersion;
+      let type: 'NONE' | 'SOFT' | 'HARD' = 'NONE';
 
-      if (!aggressive) {
-        const dismissed = await EncryptedStorage.getItem(
-          DISMISS_KEY_PREFIX + latest,
-        );
-        if (dismissed === '1') return;
+      // 1) 서버 정책 우선
+      try {
+        const policy = await fetchVersionPolicy(); // updateType: 'NONE' | 'SOFT' | 'HARD' 로 정규화되어 있다고 가정
+        type = policy.updateType;
+
+        // latest/storeUrl 업데이트 (message는 서버가 절대 안 주므로 프론트 고정 유지)
+        setLatest(policy.latestVersion ?? fallbackConfig.latestVersion);
+        setStoreUrl(policy.storeUrl);
+      } catch {
+        // 2) 실패 시 fallback 비교
+        const current = DeviceInfo.getVersion();
+        const min = fallbackConfig.minSupportedVersion;
+        if (min && cmp(current, min) < 0) type = 'HARD';
+        else if (cmp(current, fallbackConfig.latestVersion) < 0) type = 'SOFT';
       }
 
-      if (min && cmp(current, min) < 0) {
-        setMust(true);
-        setShow(true);
-        return;
+      // 3) aggressive=false면 동일 latest에 대해 "닫기" 기억
+      if (!aggressive && (type === 'SOFT' || type === 'NONE')) {
+        if (latest) {
+          const dismissed = await EncryptedStorage.getItem(
+            `${DISMISS_KEY_PREFIX}${latest}`,
+          );
+          if (dismissed === '1') return;
+        }
       }
-      if (cmp(current, latest) < 0) {
-        setMust(false);
+
+      if (type === 'SOFT' || type === 'HARD') {
+        setHard(type === 'HARD');
+        setMessage(defaultMessage ?? DEFAULT_MESSAGE); // 항상 프론트 고정 문구
         setShow(true);
       }
     })();
-  }, [conf, aggressive]);
+    // latest를 의존성에서 제거하여 setLatest 후 반복 호출 방지
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    aggressive,
+    fallbackConfig,
+    defaultMessage,
+    iosAppStoreId,
+    androidPackageName,
+  ]);
 
-  // 강제일 때 안드로이드 뒤로가기 막기
+  // 강제(HARD)일 때 안드로이드 하드웨어 뒤로가기 차단
   useEffect(() => {
     const sub = BackHandler.addEventListener(
       'hardwareBackPress',
-      () => must && show,
+      () => hard && show,
     );
     return () => sub.remove();
-  }, [must, show]);
+  }, [hard, show]);
 
   if (!show) return null;
 
-  const title = must ? '업데이트 필요' : '업데이트 권장';
-  const body = '앱을 안정적으로 사용하려면 \n최신 버전으로 업데이트 해주세요.';
-
-  const onUpdate = async () => {
-    await openStore(conf.updateUrl);
-  };
-
+  const onUpdate = () => openStore(storeUrl);
   const onLater = async () => {
     const until = Date.now() + snoozeHours * 60 * 60 * 1000;
     await EncryptedStorage.setItem(SNOOZE_KEY, String(until));
     setShow(false);
   };
-
   const onCloseThisVersion = async () => {
-    if (!aggressive) {
-      await EncryptedStorage.setItem(
-        DISMISS_KEY_PREFIX + (conf.latestVersion || ''),
-        '1',
-      );
+    if (!aggressive && latest) {
+      await EncryptedStorage.setItem(`${DISMISS_KEY_PREFIX}${latest}`, '1');
     }
     setShow(false);
   };
@@ -151,45 +195,45 @@ export default function VersionGate({
             width: '100%',
             maxWidth: 420,
             alignItems: 'center',
-            justifyContent: 'center',
           }}
         >
-          <Text style={{ fontSize: 18, fontWeight: '700', marginBottom: 8 }}>
-            {title}
+          <Text style={{ fontSize: 18, fontWeight: '700', marginBottom: 14 }}>
+            {hard ? '업데이트 필요' : '업데이트 권장'}
           </Text>
-          <Text style={{ fontSize: 14, color: '#444', marginBottom: 16 }}>
-            {body}
-          </Text>
-
-          <View
+          <Text
             style={{
-              justifyContent: 'flex-end',
-              alignItems: 'center',
+              fontSize: 14,
+              color: '#444',
+              marginBottom: 16,
+              textAlign: 'center',
             }}
           >
-            <TouchableOpacity
-              onPress={onUpdate}
-              style={{ paddingVertical: 10, paddingHorizontal: 14 }}
-            >
-              <Text style={{ fontWeight: '700' }}>지금 업데이트</Text>
-            </TouchableOpacity>
-            {!must && (
-              <>
-                <TouchableOpacity
-                  onPress={onLater}
-                  style={{ paddingVertical: 10, paddingHorizontal: 14 }}
-                >
-                  <Text>나중에</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  onPress={onCloseThisVersion}
-                  style={{ paddingVertical: 10, paddingHorizontal: 14 }}
-                >
-                  <Text>닫기</Text>
-                </TouchableOpacity>
-              </>
-            )}
-          </View>
+            {message}
+          </Text>
+
+          <TouchableOpacity
+            onPress={onUpdate}
+            style={{ paddingVertical: 10, paddingHorizontal: 14 }}
+          >
+            <Text style={{ fontWeight: '700' }}>스토어로 이동</Text>
+          </TouchableOpacity>
+
+          {!hard && (
+            <>
+              <TouchableOpacity
+                onPress={onLater}
+                style={{ paddingVertical: 10, paddingHorizontal: 14 }}
+              >
+                <Text>나중에</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onCloseThisVersion}
+                style={{ paddingVertical: 10, paddingHorizontal: 14 }}
+              >
+                <Text>닫기</Text>
+              </TouchableOpacity>
+            </>
+          )}
         </View>
       </View>
     </Modal>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/version-update` → `develop`

### 변경 사항
- **API 연동 (versionApi.ts)**
  - `/app/version` API 호출 추가
  - 서버에서 내려주는 `updateType(NONE/SELECT/FORCE)` → 클라이언트 공통 타입(`NONE/SOFT/HARD`)으로 정규화
  - 서버 미응답/에러 시 fallbackConfig(minVersion, latestVersion) 기반으로 비교 처리

- **VersionGate 컴포넌트 개선 (VersionGate.tsx)**
  - 서버 정책 기반으로 SOFT/HARD 모달 노출
  - 서버에서 message 미제공 시 프론트 기본 문구(defaultMessage) 적용
  - iOS/Android 스토어 이동 분기
    - iOS: iosAppStoreId가 있으면 해당 앱 상세 페이지, 없으면 App Store 메인
    - Android: 패키지명 기반 Play Store 페이지
  - UI 디자인 반영
    - HARD(강제 업데이트): 파란 버튼 하나만 노출
    - SOFT(권장 업데이트): 회색 "나중에" 버튼 + 파란 "스토어로 이동" 버튼
  - 텍스트 중앙 정렬 및 lineHeight 적용

- **앱 적용 (App.tsx)**
  - VersionGate 컴포넌트 마운트 및 fallbackConfig/defaultMessage 설정

### 테스트 결과
- IOS 2.3.7: minVersion(2.3.8) 미만 → 강제 업데이트 모달 노출 확인
- ANDROID 2.3.7: latestVersion(2.3.8) 미만 → 권장 업데이트 모달 노출 확인
- iOS: iosAppStoreId 미설정 시 App Store 메인 이동, 설정 시 상세 페이지 이동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 서버 연동 버전 안내 도입: NONE/SOFT/HARD에 따른 모달 노출 및 강제 차단(HARD)
  * 플랫폼별 스토어 이동: 서버 URL 우선, 기기별 스토어와 HTTPS 대체 경로 지원
  * 알림 미루기: 권장 업데이트는 24시간 동안 다시 표시 안 함
* Refactor
  * 서버 우선 정책 적용, 실패 시 로컬 기준(min 2.3.6 / latest 2.3.8)으로 대체 판단
* Style
  * 모달 UX 개선: 경고 아이콘, 동적 제목(업데이트 필요/권장), 기본 안내 문구 추가 ("안정적인 서비스 이용을 위해\n최신 버전으로 업데이트 해주세요.")
<!-- end of auto-generated comment: release notes by coderabbit.ai -->