### PR TITLE
[feat] 학식 화면 주간 API 연동 및 라우팅 (ACE/아마랜스)

### DIFF
--- a/front/src/api/cafeteriaApi.ts
+++ b/front/src/api/cafeteriaApi.ts
@@ -1,0 +1,37 @@
+import client from './axiosInstance';
+
+export type CafeteriaMenuItem = {
+  buildingId: number;
+  buildingName: string;
+  place: string;
+  mealDate: string;
+  mealType: string;
+  corner?: string;
+  items: string[];
+  itemsChoice: string[];
+  itemsCommon: string[];
+  dayIndex: number;
+  date: string;
+};
+
+export type CafeteriaWeeklyRes = {
+  tz: string;
+  serverTime: string;
+  weekStart: string;
+  todayIndex: number;
+  availableIndices: number[];
+  indexToDate?: Record<string, string>;
+  menus: CafeteriaMenuItem[];
+  lastUpdatedAt: string;
+};
+
+export async function getCafeteriaWeekly(
+  buildingId: number,
+  signal?: AbortSignal,
+) {
+  const { data } = await client.get<CafeteriaWeeklyRes>(
+    '/cafeteria/menus/weekly',
+    { params: { buildingId }, signal },
+  );
+  return data;
+}

--- a/front/src/constants/navigation.ts
+++ b/front/src/constants/navigation.ts
@@ -16,6 +16,8 @@ const mapNavigation = {
   ROUTE_SELECTION: 'RouteSelection',
   ROUTE_RESULT: 'RouteResult',
   SHUTTLE_DETAIL: 'ShuttleDetail',
+  ACE_MEAL: 'AceMealScreen',
+  AMARANTH_MEAL: 'AmaranthMealScreen',
   SHORTCUT_LIST: 'ShortcutList',
   SHORTCUT_DETAIL: 'ShortcutDetail',
 } as const;

--- a/front/src/navigations/stack/MapStackNavigator.tsx
+++ b/front/src/navigations/stack/MapStackNavigator.tsx
@@ -11,6 +11,8 @@ import ShortcutListScreen from '../../screens/map/ShortcutListScreen';
 import ShortcutDetailScreen from '../../screens/map/ShortcutDetailScreen';
 import ShuttleDetailScreen from '../../screens/map/ShuttleDetailScreen';
 import { ShuttleSchedule } from '../../api/shuttleApi';
+import AceMealScreen from '../../screens/map/AceMealScreen';
+import AmaranthMealScreen from '../../screens/map/AmaranthMealScreen';
 
 // 네비게이션 파라미터 타입 정의
 export type MapStackParamList = {
@@ -85,6 +87,8 @@ export type MapStackParamList = {
   [mapNavigation.SHORTCUT_DETAIL]: {
     shortcutId: number;
   };
+  [mapNavigation.ACE_MEAL]: undefined;
+  [mapNavigation.AMARANTH_MEAL]: undefined;
 };
 
 const Stack = createStackNavigator<MapStackParamList>();
@@ -94,6 +98,9 @@ function MapStackNavigator() {
     <Stack.Navigator
       screenOptions={{
         headerBackButtonDisplayMode: 'minimal',
+        cardStyle: {
+          backgroundColor: 'white',
+        },
       }}
     >
       <Stack.Screen
@@ -135,6 +142,25 @@ function MapStackNavigator() {
           headerTitleAlign: 'center',
         }}
       />
+      <Stack.Screen
+        name={mapNavigation.ACE_MEAL}
+        component={AceMealScreen}
+        options={{
+          title: '오늘의 학식',
+          headerTitleStyle: { fontSize: 16, fontWeight: '600' },
+          headerTitleAlign: 'center',
+        }}
+      />
+      <Stack.Screen
+        name={mapNavigation.AMARANTH_MEAL}
+        component={AmaranthMealScreen}
+        options={{
+          title: '오늘의 학식',
+          headerTitleStyle: { fontSize: 16, fontWeight: '600' },
+          headerTitleAlign: 'center',
+        }}
+      />
+
       <Stack.Screen
         name={mapNavigation.SHORTCUT_LIST}
         component={ShortcutListScreen}

--- a/front/src/navigations/tab/BottomTabNavigator.tsx
+++ b/front/src/navigations/tab/BottomTabNavigator.tsx
@@ -26,6 +26,8 @@ const hiddenScreens = [
   mapNavigation.ROUTE_SELECTION,
   mapNavigation.ROUTE_RESULT,
   mapNavigation.SHUTTLE_DETAIL,
+  mapNavigation.ACE_MEAL,
+  mapNavigation.AMARANTH_MEAL,
   mapNavigation.SHORTCUT_LIST,
   mapNavigation.SHORTCUT_DETAIL,
 ];

--- a/front/src/screens/map/AceMealScreen.tsx
+++ b/front/src/screens/map/AceMealScreen.tsx
@@ -1,5 +1,4 @@
-// screens/map/AceMealScreen.tsx
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   ScrollView,
   View,
@@ -7,27 +6,143 @@ import {
   StyleSheet,
   Pressable,
   Image,
+  ActivityIndicator,
 } from 'react-native';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
 import { colors } from '../../constants';
+import { getCafeteriaWeekly, CafeteriaMenuItem } from '../../api/cafeteriaApi';
+
+dayjs.locale('ko');
+
+const BUILDING_ID = 5;
 
 export default function AceMealScreen() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // index → 메뉴목록
+  const [byIndex, setByIndex] = useState<Record<number, CafeteriaMenuItem[]>>(
+    {},
+  );
+  // 이동 가능한 인덱스들 [0,1,2,3,4]
+  const [available, setAvailable] = useState<number[]>([]);
+  // available 배열에서의 포인터
+  const [ptr, setPtr] = useState(0);
+  // index → ISO date
+  const [indexToDate, setIndexToDate] = useState<Record<number, string>>({});
+  // 헤더 타이틀(응답 없을 때 대비)
+  const [buildingTitle, setBuildingTitle] = useState('ACE교육관');
+
+  useEffect(() => {
+    const ac = new AbortController();
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await getCafeteriaWeekly(BUILDING_ID, ac.signal);
+
+        // 인덱스별 그룹핑
+        const grouped: Record<number, CafeteriaMenuItem[]> = {};
+        res.menus.forEach(m => {
+          (grouped[m.dayIndex] ||= []).push(m);
+        });
+
+        // 이동 가능한 요일
+        const av = (
+          res.availableIndices || Object.keys(grouped).map(Number)
+        ).sort((a, b) => a - b);
+
+        // 포인터 초기화: available 안에서 todayIndex의 위치
+        const todayPos = av.indexOf(res.todayIndex);
+        setPtr(todayPos >= 0 ? todayPos : 0);
+
+        // date 매핑
+        const map: Record<number, string> = {};
+        if (res.indexToDate) {
+          Object.entries(res.indexToDate).forEach(
+            ([k, v]) => (map[Number(k)] = v),
+          );
+        } else {
+          const base = new Date(res.weekStart + 'T00:00:00');
+          av.forEach(idx => {
+            const d = new Date(base.getTime() + idx * 86400000);
+            map[idx] = d.toISOString().slice(0, 10);
+          });
+        }
+
+        setByIndex(grouped);
+        setAvailable(av);
+        setIndexToDate(map);
+        // 빌딩명(첫 항목 기준)
+        const name =
+          res.menus.find(m => !!m.buildingName)?.buildingName || buildingTitle;
+        setBuildingTitle(name);
+      } catch (e) {
+        setError('학식 정보를 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    })();
+
+    return () => ac.abort();
+  }, []);
+
+  const selectedIndex = useMemo(
+    () => (available.length ? available[ptr] : 0),
+    [available, ptr],
+  );
+
+  const selectedDateISO = indexToDate[selectedIndex];
+  const dateLabel = selectedDateISO
+    ? dayjs(selectedDateISO).format('M월 D일 dddd')
+    : '';
+
+  const mealsForSelected = byIndex[selectedIndex] || [];
+
+  // ACE 화면: 점심(중식) × [학생식당, 교직원식당]
+  const lunchStudent = mealsForSelected.filter(
+    m => m.mealType?.includes('중식') && m.place?.includes('학생'),
+  );
+  const lunchStaff = mealsForSelected.filter(
+    m => m.mealType?.includes('중식') && m.place?.includes('교직원'),
+  );
+
+  const onPrev = () => {
+    if (ptr > 0) setPtr(p => p - 1);
+  };
+  const onNext = () => {
+    if (ptr < available.length - 1) setPtr(p => p + 1);
+  };
+
+  const leftDisabled = ptr <= 0;
+  const rightDisabled = ptr >= available.length - 1;
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
-      {/* 상단 헤더 */}
+      {/* 헤더 */}
       <View style={styles.header}>
         <View style={{ flex: 1 }}>
-          <Text style={styles.buildingTitle}>종합강의동</Text>
-          <Text style={styles.dateLabel}>9월 8일 월요일</Text>
+          <Text style={styles.buildingTitle}>{buildingTitle}</Text>
+          <Text style={styles.dateLabel}>{dateLabel}</Text>
         </View>
         <View style={styles.dateNavBox}>
-          <Pressable style={styles.navBtn}>
+          <Pressable
+            style={[styles.navBtn, leftDisabled && { opacity: 0.4 }]}
+            onPress={onPrev}
+            disabled={leftDisabled}
+          >
             <Image
               source={require('../../assets/back-icon.png')}
               style={{ width: 7, height: 11 }}
             />
           </Pressable>
           <View style={styles.navDivider} />
-          <Pressable style={styles.navBtn}>
+          <Pressable
+            style={[styles.navBtn, rightDisabled && { opacity: 0.4 }]}
+            onPress={onNext}
+            disabled={rightDisabled}
+          >
             <Image
               source={require('../../assets/back-icon.png')}
               style={{ width: 7, height: 11, transform: [{ scaleX: -1 }] }}
@@ -36,44 +151,58 @@ export default function AceMealScreen() {
         </View>
       </View>
 
-      {/* 점심 */}
       <Text style={styles.sectionTitle}>점심</Text>
       <Text style={styles.timeText}>11:30 - 14:00</Text>
 
-      <View style={styles.card}>
-        <Text style={styles.subTitle}>학생 식당</Text>
-        <Text style={styles.menu}>
-          아비꼬카레/가라아게, 양배추샐러드, 백미밥, 가스오장국, 단무지,
-          배추김치
-        </Text>
-      </View>
+      {loading && <ActivityIndicator style={{ marginTop: 12 }} />}
+      {error && <Text style={{ color: 'red', marginBottom: 8 }}>{error}</Text>}
 
-      <View style={styles.card}>
-        <Text style={styles.subTitle}>교직원 식당</Text>
-        <Text style={styles.menu}>
-          흑미밥/백미밥, 황태무국, 대파제육볶음, 고등어무조림, 매콤쫄면,
-          아삭이오이고추된장무침, 콩나물무침, 쌈채소, 건강샐러드, 국내산김치2종,
-          후식차
-        </Text>
-      </View>
+      {!loading && !error && (
+        <>
+          <View style={styles.card}>
+            <Text style={styles.subTitle}>학생 식당</Text>
+            <Text style={styles.menu}>
+              {lunchStudent.length
+                ? lunchStudent
+                    .map(m =>
+                      [...(m.items || []), ...(m.itemsCommon || [])].join(', '),
+                    )
+                    .join('\n')
+                : '매뉴 준비 중'}
+            </Text>
+          </View>
 
-      <View style={{ height: 46 }} />
+          <View style={styles.card}>
+            <Text style={styles.subTitle}>교직원 식당</Text>
+            <Text style={styles.menu}>
+              {lunchStaff.length
+                ? lunchStaff
+                    .map(m =>
+                      [...(m.items || []), ...(m.itemsCommon || [])].join(', '),
+                    )
+                    .join('\n')
+                : '메뉴 준비 중'}
+            </Text>
+          </View>
 
-      {/* 이용 안내 */}
-      <Text style={styles.infoTitle}>이용안내</Text>
-      <Text style={styles.infoSubTitle}>학생식당</Text>
-      {/* <View style={styles.infoTextBox}> */}
-      <Text style={styles.infoText}>일품코너 : 6,500원 (돈까스, 덮밥류)</Text>
-      <Text style={styles.infoText}>간편식 샐러드 : 5,800원</Text>
-      <Text style={styles.infoText}>
-        즉석 셀프 라면 : 4,500원 (밥, 토핑 포함)
-      </Text>
-      {/* </View> */}
+          <View style={{ height: 46 }} />
 
-      <View style={{ height: 18 }} />
+          {/* 이용 안내 (고정문구) */}
+          <Text style={styles.infoTitle}>이용안내</Text>
+          <Text style={styles.infoSubTitle}>학생식당</Text>
+          <Text style={styles.infoText}>
+            일품코너 : 6,500원 (돈까스, 덮밥류)
+          </Text>
+          <Text style={styles.infoText}>간편식 샐러드 : 5,800원</Text>
+          <Text style={styles.infoText}>
+            즉석 셀프 라면 : 4,500원 (밥, 토핑 포함)
+          </Text>
 
-      <Text style={styles.infoSubTitle}>교직원식당</Text>
-      <Text style={styles.infoText}>한식과 직화 일품뚝배기 : 9,000원</Text>
+          <View style={{ height: 18 }} />
+          <Text style={styles.infoSubTitle}>교직원식당</Text>
+          <Text style={styles.infoText}>한식과 직화 일품뚝배기 : 9,000원</Text>
+        </>
+      )}
     </ScrollView>
   );
 }
@@ -161,9 +290,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     color: colors.BLACK_500,
     marginBottom: 6,
-  },
-  infoTextBox: {
-    marginBottom: 16,
   },
   infoText: {
     fontSize: 12,

--- a/front/src/screens/map/AceMealScreen.tsx
+++ b/front/src/screens/map/AceMealScreen.tsx
@@ -1,0 +1,174 @@
+// screens/map/AceMealScreen.tsx
+import React from 'react';
+import {
+  ScrollView,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Image,
+} from 'react-native';
+import { colors } from '../../constants';
+
+export default function AceMealScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {/* 상단 헤더 */}
+      <View style={styles.header}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.buildingTitle}>종합강의동</Text>
+          <Text style={styles.dateLabel}>9월 8일 월요일</Text>
+        </View>
+        <View style={styles.dateNavBox}>
+          <Pressable style={styles.navBtn}>
+            <Image
+              source={require('../../assets/back-icon.png')}
+              style={{ width: 7, height: 11 }}
+            />
+          </Pressable>
+          <View style={styles.navDivider} />
+          <Pressable style={styles.navBtn}>
+            <Image
+              source={require('../../assets/back-icon.png')}
+              style={{ width: 7, height: 11, transform: [{ scaleX: -1 }] }}
+            />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* 점심 */}
+      <Text style={styles.sectionTitle}>점심</Text>
+      <Text style={styles.timeText}>11:30 - 14:00</Text>
+
+      <View style={styles.card}>
+        <Text style={styles.subTitle}>학생 식당</Text>
+        <Text style={styles.menu}>
+          아비꼬카레/가라아게, 양배추샐러드, 백미밥, 가스오장국, 단무지,
+          배추김치
+        </Text>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.subTitle}>교직원 식당</Text>
+        <Text style={styles.menu}>
+          흑미밥/백미밥, 황태무국, 대파제육볶음, 고등어무조림, 매콤쫄면,
+          아삭이오이고추된장무침, 콩나물무침, 쌈채소, 건강샐러드, 국내산김치2종,
+          후식차
+        </Text>
+      </View>
+
+      <View style={{ height: 46 }} />
+
+      {/* 이용 안내 */}
+      <Text style={styles.infoTitle}>이용안내</Text>
+      <Text style={styles.infoSubTitle}>학생식당</Text>
+      {/* <View style={styles.infoTextBox}> */}
+      <Text style={styles.infoText}>일품코너 : 6,500원 (돈까스, 덮밥류)</Text>
+      <Text style={styles.infoText}>간편식 샐러드 : 5,800원</Text>
+      <Text style={styles.infoText}>
+        즉석 셀프 라면 : 4,500원 (밥, 토핑 포함)
+      </Text>
+      {/* </View> */}
+
+      <View style={{ height: 18 }} />
+
+      <Text style={styles.infoSubTitle}>교직원식당</Text>
+      <Text style={styles.infoText}>한식과 직화 일품뚝배기 : 9,000원</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 24,
+  },
+  buildingTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.BLACK_900,
+  },
+  dateLabel: {
+    marginTop: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.GRAY_500,
+  },
+  dateNavBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#EBEDF0',
+  },
+  navBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  navDivider: {
+    width: 1,
+    alignSelf: 'stretch',
+    backgroundColor: '#EBEDF0',
+  },
+  sectionTitle: {
+    color: colors.BLUE_700,
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  timeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.GRAY_500,
+    marginBottom: 18,
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 14,
+    marginBottom: 18,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  subTitle: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.GRAY_500,
+    marginBottom: 10,
+  },
+  menu: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 22,
+    color: colors.BLACK_900,
+  },
+  infoTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.BLACK_900,
+    marginBottom: 12,
+  },
+  infoSubTitle: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.BLACK_500,
+    marginBottom: 6,
+  },
+  infoTextBox: {
+    marginBottom: 16,
+  },
+  infoText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.GRAY_500,
+    marginBottom: 4,
+  },
+});

--- a/front/src/screens/map/AmaranthMealScreen.tsx
+++ b/front/src/screens/map/AmaranthMealScreen.tsx
@@ -54,9 +54,6 @@ export default function AmaranthMealScreen() {
           res.availableIndices || Object.keys(grouped).map(Number)
         ).sort((a, b) => a - b);
 
-        const todayPos = av.indexOf(res.todayIndex);
-        setPtr(todayPos >= 0 ? todayPos : 0);
-
         setTz(res.tz || 'Asia/Seoul');
 
         const map: Record<number, string> = {};
@@ -69,6 +66,22 @@ export default function AmaranthMealScreen() {
           });
         }
         setIndexToDate(map);
+
+        const todayPos = av.indexOf((res.todayIndex as number) ?? -999);
+        const initialPtr = (() => {
+          if (todayPos >= 0) return todayPos;
+          const dates = av.map(i => map[i]).sort(); // ISO 문자열
+          if (dates.length === 0) return 0;
+          const todayISO = (res.serverTime || new Date().toISOString()).slice(
+            0,
+            10,
+          );
+          if (todayISO <= dates[0]) return 0;
+          if (todayISO >= dates[dates.length - 1]) return dates.length - 1;
+          const k = dates.findIndex(d => d >= todayISO);
+          return k === -1 ? dates.length - 1 : k;
+        })();
+        setPtr(initialPtr);
 
         if (canceled || ac.signal.aborted) return;
         setByIndex(grouped);

--- a/front/src/screens/map/AmaranthMealScreen.tsx
+++ b/front/src/screens/map/AmaranthMealScreen.tsx
@@ -1,0 +1,179 @@
+// screens/map/AmaranthMealScreen.tsx
+import React from 'react';
+import {
+  ScrollView,
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Image,
+} from 'react-native';
+import { colors } from '../../constants';
+
+export default function AmaranthMealScreen() {
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {/* 상단 헤더 */}
+      <View style={styles.header}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.buildingTitle}>아마란스홀</Text>
+          <Text style={styles.dateLabel}>9월 8일 월요일</Text>
+        </View>
+        <View style={styles.dateNavBox}>
+          <Pressable style={styles.navBtn}>
+            <Image
+              source={require('../../assets/back-icon.png')}
+              style={{ width: 7, height: 11 }}
+            />
+          </Pressable>
+          <View style={styles.navDivider} />
+          <Pressable style={styles.navBtn}>
+            <Image
+              source={require('../../assets/back-icon.png')}
+              style={{ width: 7, height: 11, transform: [{ scaleX: -1 }] }}
+            />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* 점심 */}
+      <Text style={styles.sectionTitle}>점심</Text>
+      <Text style={styles.timeText}>11:30 - 14:00</Text>
+
+      <View style={styles.card}>
+        <Text style={styles.subTitle}>선택메뉴</Text>
+        <Text style={styles.menu}>
+          수제돈까스, 햄김치볶음밥, 마제덮밥, 지코바치킨덮밥, 왕새우튀김우동
+        </Text>
+
+        <View style={styles.divider} />
+
+        <Text style={styles.subTitle}>공통찬</Text>
+        <Text style={styles.menu}>
+          불어묵강정, 숙주오이무침, 배추김치, 가쓰오장국
+        </Text>
+      </View>
+
+      <View style={{ height: 32 }} />
+
+      {/* 저녁 */}
+      <View style={styles.cardBox}>
+        <Text style={styles.sectionTitle}>저녁</Text>
+        <Text style={styles.timeText}>18:00 - 19:00</Text>
+
+        <View style={styles.card}>
+          <Text style={styles.menu}>
+            햄모듬김치찌개, 백미밥, 너비아니파채무침, 불닭팽이버섯찜,
+            모듬콩조림, 배추김치
+          </Text>
+        </View>
+      </View>
+
+      {/* 이용 안내 */}
+      <Text style={styles.infoTitle}>이용안내</Text>
+      <Text style={styles.infoSubTitle}>학생식당</Text>
+      <Text style={styles.infoText}>Mom’s Cook : 6,500원</Text>
+      <Text style={styles.infoText}>돈까스코너 : 6,500원</Text>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 24,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 24, // Ace와 동일
+  },
+  buildingTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: colors.BLACK_900,
+  },
+  dateLabel: {
+    marginTop: 6,
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.GRAY_500,
+  },
+  dateNavBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#EBEDF0',
+  },
+  navBtn: {
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+  },
+  navDivider: {
+    width: 1,
+    alignSelf: 'stretch', // 부모 높이에 맞춤 (Ace와 동일)
+    backgroundColor: '#EBEDF0',
+  },
+  sectionTitle: {
+    color: colors.BLUE_700,
+    fontSize: 20,
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  timeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.GRAY_500,
+    marginBottom: 18, // Ace와 동일
+  },
+  cardBox: {
+    marginBottom: 46, // Ace와 동일 섹션 간 간격
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 14,
+    marginBottom: 18,
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  subTitle: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.GRAY_500,
+    marginBottom: 10,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#EBEDF0',
+    marginVertical: 12,
+  },
+  menu: {
+    fontSize: 14,
+    fontWeight: '600',
+    lineHeight: 22,
+    color: colors.BLACK_900,
+  },
+  infoTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.BLACK_900,
+    marginBottom: 12,
+  },
+  infoSubTitle: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.BLACK_500,
+    marginBottom: 6,
+  },
+  infoText: {
+    fontSize: 12,
+    fontWeight: '500',
+    color: colors.GRAY_500,
+    marginBottom: 4,
+  },
+});

--- a/front/src/screens/map/MapHomeScreen.tsx
+++ b/front/src/screens/map/MapHomeScreen.tsx
@@ -267,6 +267,20 @@ function MapHomeScreen() {
         return;
       }
 
+      if (data.type === 'cafeteriaClicked' && data.buildingId) {
+        setOpenSheet(null);
+        // buildingId 매핑 → 학식 페이지 이동
+        if (data.buildingId === 5) {
+          navigation.navigate(mapNavigation.ACE_MEAL);
+          return;
+        }
+        if (data.buildingId === 12) {
+          navigation.navigate(mapNavigation.AMARANTH_MEAL);
+          return;
+        }
+        return;
+      }
+
       if (data.type === 'selectFacility' && data.buildingId) {
         setOpenSheet(null);
         requestAnimationFrame(() => {
@@ -277,7 +291,9 @@ function MapHomeScreen() {
           });
         });
         return;
-      } else if (data.type === 'shuttleClicked') {
+      }
+
+      if (data.type === 'shuttleClicked') {
         setLoadingSchedule(true);
         try {
           if (!data.stopId) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/restaurant-meal` → `develop`

### 변경 사항
- **네비게이션**
  - `mapNavigation`에 `ACE_MEAL`, `AMARANTH_MEAL` 라우트 추가 및 스택 등록
  - WebView 메시지 `cafeteriaClicked` 수신 시:
    - `buildingId === 5` → `ACE_MEAL`
    - `buildingId === 12` → `AMARANTH_MEAL`
  - 다른 시설 마커(기존 `selectFacility`, `shuttleClicked`) 동작 영향 없음

- **API**
  - `GET /cafeteria/menus/weekly?buildingId={5|12}` 클라이언트 추가 (`src/api/cafeteriaApi.ts`)
  - 타입 정의: `CafeteriaWeeklyRes`, `CafeteriaMenuItem`
  - **컨벤션 준수:** `axiosInstance` 사용, **원본 응답 그대로 반환**

- **화면(UI)**
  - `AceMealScreen.tsx` (ACE교육관), `AmaranthMealScreen.tsx` (아마랜스홀)
  - 주간 데이터(월~금) 1회 로드 → **요일 인덱스(dayIndex) 그룹핑**
  - 상단 날짜 네비게이션(◀▶): 같은 주 내에서 `ptr`만 이동 (재호출 없음)
  - 날짜 라벨:
    - `indexToDate`가 있으면 우선 사용
    - 없으면 `weekStart + dayIndex`로 계산
  - 응답의 `buildingName`을 헤더 타이틀로 표기

### 테스트 결과
- 식당 마커 탭 →  
     - `buildingId=5` → ACE 화면  
     - `buildingId=12` → 아마랜스 화면

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - ACE교육관·아마란스홀 학식 화면 추가: 주간 메뉴 조회, 날짜 이동, 로딩/에러 처리, 메뉴 준비 중 안내, 이용안내(가격) 표시.
  - 카페테리아 주간 메뉴 조회용 API 클라이언트(getCafeteriaWeekly) 및 관련 응답 타입 추가.

- 내비게이션
  - 지도에서 해당 식당 선택 시 각 학식 화면으로 이동.
  - 신규 화면은 탭바에서 숨김 처리 및 헤더 제목 통일("오늘의 학식").

- 리팩터
  - Map 홈 화면 클릭 처리 흐름 소폭 정리(기능 동일).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->